### PR TITLE
flush para evitar que quede el xml sin cerrar

### DIFF
--- a/afirma-server-triphase-signer/src/main/java/es/gob/afirma/signers/batch/server/BatchPostsigner.java
+++ b/afirma-server-triphase-signer/src/main/java/es/gob/afirma/signers/batch/server/BatchPostsigner.java
@@ -188,6 +188,7 @@ public final class BatchPostsigner extends HttpServlet {
 		response.setContentType("text/xml;charset=UTF-8"); //$NON-NLS-1$
 		final PrintWriter writer = response.getWriter();
 		writer.write(ret);
+		writer.flush();
 	}
 
 }


### PR DESCRIPTION
flush para evitar que quede el xml sin cerrar.
Al no hacer flush potencialmente puede ser que no se vuelque el contenido de la ultima linea (en este caso "</signs>")