### PR TITLE
Fix tests

### DIFF
--- a/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestAOKeystoreFactory.java
+++ b/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestAOKeystoreFactory.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import javax.security.auth.callback.PasswordCallback;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import es.gob.afirma.core.misc.AOUtil;
@@ -49,6 +50,7 @@ public class TestAOKeystoreFactory {
 	@Test
 //	@Ignore // Solo para Windows
     public void testAOKeystoreFactoryCAPI() throws Exception {
+    	Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS());
     	Logger.getLogger("es.gob.afirma").setLevel(Level.WARNING); //$NON-NLS-1$
     	final AOKeyStoreManager ksm = AOKeyStoreManagerFactory.getAOKeyStoreManager(
 			AOKeyStore.WINDOWS, // Store

--- a/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestKeyStoreWindowsCertACA.java
+++ b/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestKeyStoreWindowsCertACA.java
@@ -21,6 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import es.gob.afirma.core.misc.AOUtil;
@@ -86,6 +87,7 @@ public class TestKeyStoreWindowsCertACA {
     @SuppressWarnings("static-method")
 	@Test
     public void testMSCapi() throws Exception {
+    	Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS());
 
     	final String ALIAS = "EA=demo.empleado@cgae.redabogacia.org, CN=NOMBRE EMPLEADO EMPLEADO DEMO - NIF 08967425R, OU=Informatica, O=Consejo General de la Abogac\u00EDa Espa\u00F1ola / CGAE / 2000, C=ES, ST=Madrid, OID.2.5.4.12=#1308506572736F6E616C, OID.1.3.6.1.4.1.4710.1.3.2=#1309513238363330303649, OID.2.5.4.5=#1309303839363734323552, OID.2.5.4.42=#130444454D4F, OID.2.5.4.4=#1308454D504C4541444F, OID.1.3.6.1.4.1.16533.30.1=#1308454D504C4541444F"; //$NON-NLS-1$
 

--- a/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestPkcs11.java
+++ b/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestPkcs11.java
@@ -10,8 +10,10 @@ import java.security.Security;
 import java.security.Signature;
 import java.util.Enumeration;
 
+import org.junit.Assume;
 import org.junit.Test;
 
+import es.gob.afirma.core.misc.Platform;
 import es.gob.afirma.keystores.AOKeyStore;
 import es.gob.afirma.keystores.AOKeyStoreManager;
 import es.gob.afirma.keystores.AOKeyStoreManagerFactory;
@@ -60,7 +62,7 @@ public final class TestPkcs11 {
 	@Test
 	//@Ignore // Dependiente del PKCS#11
 	public void testRawPkcs11() throws Exception {
-
+		Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS());
         final Constructor<?> sunPKCS11Contructor = Class.forName("sun.security.pkcs11.SunPKCS11").getConstructor(InputStream.class); //$NON-NLS-1$
         final Provider p = (Provider) sunPKCS11Contructor.newInstance(
     		new ByteArrayInputStream((

--- a/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestPkcs11.java
+++ b/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestPkcs11.java
@@ -1,6 +1,7 @@
 package es.gob.afirma.test.keystores;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.security.KeyStore;
@@ -10,10 +11,12 @@ import java.security.Security;
 import java.security.Signature;
 import java.util.Enumeration;
 
-import org.junit.Assume;
+import javax.security.auth.callback.PasswordCallback;
+
 import org.junit.Test;
 
 import es.gob.afirma.core.misc.Platform;
+import es.gob.afirma.core.misc.Platform.OS;
 import es.gob.afirma.keystores.AOKeyStore;
 import es.gob.afirma.keystores.AOKeyStoreManager;
 import es.gob.afirma.keystores.AOKeyStoreManagerFactory;
@@ -22,24 +25,15 @@ import es.gob.afirma.keystores.AOKeyStoreManagerFactory;
  * @author Tom&aacute;s Garc&iacute;a-Mer&aacute;s */
 public final class TestPkcs11 {
 
-	//private static final String LIB_NAME = "C:\\WINDOWS\\System32\\DNIe_P11_priv.dll"; //$NON-NLS-1$
-	//private static final String LIB_NAME = "C:\\WINDOWS\\SysWOW64\\siecap11.dll"; //$NON-NLS-1$
-	//private static final String LIB_NAME = "C:\\Users\\tomas\\workspace_32\\afirma-core-keystores\\src\\test\\resources\\CardOS\\cardos11.dll"; //$NON-NLS-1$
-	//private static final String LIB_NAME = "C:\\WINDOWS\\SysWOW64\\cardos11.dll"; //$NON-NLS-1$
-	//private static final String LIB_NAME = "C:\\WINDOWS\\SysWOW64\\TIF_P11.dll"; //$NON-NLS-1$
-	private static final String LIB_NAME = "C:\\WINDOWS\\SysWOW64\\DNIe_P11_priv.dll"; //$NON-NLS-1$
-	private static final char[] PIN = "12345678".toCharArray(); //$NON-NLS-1$
 
 	/** Prueba de firma con PKCS#11.
 	 * @throws Exception En cualquier error. */
 	@SuppressWarnings("static-method")
 	@Test
-	//@Ignore //Dependiente del PKCS#11
 	public void testPkcs11() throws Exception {
-		Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS());
 		final AOKeyStoreManager ksm = AOKeyStoreManagerFactory.getAOKeyStoreManager(
     		AOKeyStore.PKCS11,
-    		LIB_NAME,
+    		getLibNameByOS(),
     		"Afirma-P11", //$NON-NLS-1$
     		AOKeyStore.PKCS11.getStorePasswordCallback(null),
     		null
@@ -57,29 +51,38 @@ public final class TestPkcs11 {
 
 	}
 
+
 	/** Prueba de firma con PKCS#11 usando directamente JRE.
 	 * @throws Exception En cualquier error. */
 	@SuppressWarnings("static-method")
 	@Test
-	//@Ignore // Dependiente del PKCS#11
 	public void testRawPkcs11() throws Exception {
-		Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS());
         final Constructor<?> sunPKCS11Contructor = Class.forName("sun.security.pkcs11.SunPKCS11").getConstructor(InputStream.class); //$NON-NLS-1$
         final Provider p = (Provider) sunPKCS11Contructor.newInstance(
     		new ByteArrayInputStream((
 				"name=pkcs11-win_dll\n" + //$NON-NLS-1$
-				"library=" + LIB_NAME + "\n" + //$NON-NLS-1$ //$NON-NLS-2$
+				"library=" + getLibNameByOS() + "\n" + //$NON-NLS-1$ //$NON-NLS-2$
 				"showInfo=false" //$NON-NLS-1$
 			).getBytes())
 		);
 
 		Security.addProvider(p);
 
+		
+		
+		PasswordCallback c = AOKeyStore.PKCS11.getStorePasswordCallback(null);
+		char[] password = c.getPassword();
+
 		final KeyStore ks = KeyStore.getInstance("PKCS11"); //$NON-NLS-1$
-		ks.load(null, PIN);
+		ks.load(null, password);
 		final Enumeration<String> aliases = ks.aliases();
-		final String alias = aliases.nextElement();
+		String alias = aliases.nextElement();
 		System.out.println("Alias para la firma: " + alias); //$NON-NLS-1$
+		if ("CertAutenticacion".equals(alias)) {
+			alias = aliases.nextElement();
+			System.out.println("Alias para la firma: " + alias); //$NON-NLS-1$
+		}
+		
 
 		final Signature s = Signature.getInstance("SHA1withRSA", p); //$NON-NLS-1$
 		s.initSign(
@@ -98,12 +101,21 @@ public final class TestPkcs11 {
 		System.out.println("Firma: " + new String(s.sign())); //$NON-NLS-1$
 
 	}
-
-	/** M&eacute;todo de entrada.
-	 * @param args No se usa.
-	 * @throws Exception En cualquier error. */
-	public static void main(final String args[]) throws Exception {
-		new TestPkcs11().testPkcs11();
+	
+	
+	private String getLibNameByOS() {
+		File f = null;
+		if (Platform.getOS() == OS.LINUX ) {
+			f = new File("/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so");
+		}
+		else if (Platform.getOS() == OS.WINDOWS) {
+			f = new File ("C:\\WINDOWS\\SysWOW64\\DNIe_P11_priv.dll"	);
+		}
+		if (f.exists() && f.canRead()) {
+			return f.getAbsolutePath();
+		}
+		return null;
 	}
+
 
 }

--- a/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestPkcs11.java
+++ b/afirma-core-keystores/src/test/java/es/gob/afirma/test/keystores/TestPkcs11.java
@@ -36,6 +36,7 @@ public final class TestPkcs11 {
 	@Test
 	//@Ignore //Dependiente del PKCS#11
 	public void testPkcs11() throws Exception {
+		Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS());
 		final AOKeyStoreManager ksm = AOKeyStoreManagerFactory.getAOKeyStoreManager(
     		AOKeyStore.PKCS11,
     		LIB_NAME,

--- a/afirma-core/src/test/java/es/gob/afirma/core/misc/http/TestDataDownloader.java
+++ b/afirma-core/src/test/java/es/gob/afirma/core/misc/http/TestDataDownloader.java
@@ -8,6 +8,8 @@ import java.net.URL;
 import org.junit.Test;
 
 import es.gob.afirma.core.misc.AOUtil;
+import es.gob.afirma.core.misc.Platform;
+import es.gob.afirma.core.misc.Platform.OS;
 
 /** Prueba de descarga de datos.
  * @author Tom&aacute;s Garc&iacute;a-Mer&aacute;s. */
@@ -77,16 +79,19 @@ public final class TestDataDownloader {
 	@SuppressWarnings("static-method")
 	@Test
 	public void testDataDownloaderFile() throws Exception {
-		final byte[] data = DataDownloader.downloadData(
-			"file://c:/Windows/WindowsUpdate.log" //$NON-NLS-1$
-		);
+		OS os = Platform.getOS();
+		String fileName = "file://c:/Windows/WindowsUpdate.log"; //$NON-NLS-1$
+		if (Platform.OS.LINUX == os || Platform.OS.SOLARIS == os) {
+			fileName = "file:///etc/timezone"; //$NON-NLS-1$
+		}
+		final byte[] data = DataDownloader.downloadData(fileName);
 		System.out.println(new String(data));
 	}
 
 	/** Prueba de lectura de URL inexistente.
 	 * @throws Exception En cualquier error. */
 	@SuppressWarnings("static-method")
-	@Test
+	@Test(expected=java.net.UnknownHostException.class)
 	public void testDataDownloaderInvalidUrl() throws Exception {
 		final byte[] data = UrlHttpManagerFactory.getInstalledManager().readUrl(
 			"http://dasdasdasd.asd?kaka=caca", //$NON-NLS-1$

--- a/afirma-core/src/test/java/es/gob/afirma/core/misc/http/TestHttpConnection.java
+++ b/afirma-core/src/test/java/es/gob/afirma/core/misc/http/TestHttpConnection.java
@@ -16,7 +16,7 @@ public final class TestHttpConnection {
 		Assert.assertNotNull(
 			new es.gob.afirma.core.misc.http.UrlHttpManagerImpl().readUrl(
 				"https://valide.redsara.es/valide/",  //$NON-NLS-1$
-				UrlHttpMethod.POST
+				UrlHttpMethod.GET
 			)
 		);
 	}

--- a/afirma-crypto-cades-multi/src/test/java/es/gob/afirma/signers/multi/cades/TestINC189027.java
+++ b/afirma-crypto-cades-multi/src/test/java/es/gob/afirma/signers/multi/cades/TestINC189027.java
@@ -41,7 +41,7 @@ public class TestINC189027 {
 
 	/** Prueba de contrafirma de una firma CAdES-T.
 	 * @throws Exception Cuando ocurre un error. */
-	@Test
+	@Test(expected=AOFormatFileException.class)
 	public void testContrafirmaCAdEST() throws Exception {
 
 		final InputStream is = getClass().getClassLoader().getResourceAsStream(FILE_CADES_T);
@@ -54,22 +54,17 @@ public class TestINC189027 {
 		final AOCAdESSigner signer = new AOCAdESSigner();
 
 		final byte[] countersign;
-		try {
-			countersign = signer.countersign(
-				signature,
-				AOSignConstants.SIGN_ALGORITHM_SHA512WITHRSA,
-				CounterSignTarget.TREE,
-				null,
-				pke.getPrivateKey(),
-				pke.getCertificateChain(),
-				config
-			);
-		}
-		catch(final AOFormatFileException e) {
-			return;
-		}
 
-		Assert.fail("Deberia haber saltado un AOFormatFileException"); //$NON-NLS-1$
+		countersign = signer.countersign(
+			signature,
+			AOSignConstants.SIGN_ALGORITHM_SHA512WITHRSA,
+			CounterSignTarget.TREE,
+			null,
+			pke.getPrivateKey(),
+			pke.getCertificateChain(),
+			config
+		);
+
 
 //		final File tempFile = File.createTempFile("CAdES-T-Countersign", ".csig"); //$NON-NLS-1$ //$NON-NLS-2$
 //		System.out.println("El resultado de la contrafirma de CAdES-T se almacena en: " + tempFile.getAbsolutePath()); //$NON-NLS-1$
@@ -80,7 +75,7 @@ public class TestINC189027 {
 
 	/** Prueba de cofirma de una firma CAdES-T.
 	 * @throws Exception Cuando ocurre un error. */
-	@Test
+	@Test(expected=AOFormatFileException.class)
 	public void testCofirmaCAdEST() throws Exception {
 
 		final InputStream is = getClass().getClassLoader().getResourceAsStream(FILE_CADES_T);
@@ -93,21 +88,16 @@ public class TestINC189027 {
 		final AOCAdESSigner signer = new AOCAdESSigner();
 
 		final byte[] countersign;
-		try {
-			countersign = signer.cosign(
-				AOUtil.getDataFromInputStream(TestINC189027.class.getResourceAsStream("/Original.pdf")), //$NON-NLS-1$
-				signature,
-				AOSignConstants.SIGN_ALGORITHM_SHA512WITHRSA,
-				pke.getPrivateKey(),
-				pke.getCertificateChain(),
-				config
-			);
-		}
-		catch(final AOFormatFileException e) {
-			return;
-		}
 
-		Assert.fail("Deberia haber saltado un AOFormatFileException"); //$NON-NLS-1$
+		countersign = signer.cosign(
+			AOUtil.getDataFromInputStream(TestINC189027.class.getResourceAsStream("/Original.pdf")), //$NON-NLS-1$
+			signature,
+			AOSignConstants.SIGN_ALGORITHM_SHA512WITHRSA,
+			pke.getPrivateKey(),
+			pke.getCertificateChain(),
+			config
+		);
+
 
 //		final File tempFile = File.createTempFile("CAdES-T-Cosign", ".csig"); //$NON-NLS-1$ //$NON-NLS-2$
 //		System.out.println("El resultado de la cofirma de CAdES-T se almacena en: " + tempFile.getAbsolutePath()); //$NON-NLS-1$

--- a/afirma-crypto-cades/src/test/java/es/gob/afirma/test/cades/TestSignHash.java
+++ b/afirma-crypto-cades/src/test/java/es/gob/afirma/test/cades/TestSignHash.java
@@ -29,7 +29,7 @@ public class TestSignHash {
 	PrivateKeyEntry pke = null;
 
 	@Before
-	private void loadResources() throws Exception {
+	public void loadResources() throws Exception {
 
 		Logger.getLogger("es.gob.afirma").setLevel(Level.WARNING); //$NON-NLS-1$
 

--- a/afirma-crypto-core-pkcs7/src/test/java/es/gob/afirma/signers/pkcs7/TestBcChecker.java
+++ b/afirma-crypto-core-pkcs7/src/test/java/es/gob/afirma/signers/pkcs7/TestBcChecker.java
@@ -1,5 +1,6 @@
 package es.gob.afirma.signers.pkcs7;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 /** Pruebas de la comprobaci&oacute;n de la versi&oacute;n de BouncyCastle.
@@ -9,6 +10,7 @@ public final class TestBcChecker {
 	/** Prueba la comprobaci&oacute;n de la versi&oacute;n de BouncyCastle. */
 	@SuppressWarnings("static-method")
 	@Test
+	@Ignore // Ya no se usa BouncyCastle, además BCChecker solo se usa en este test
 	public void testBcCheck() {
 		new BCChecker().checkBouncyCastle();
 	}

--- a/afirma-keystores-filters/src/test/java/es/gob/afirma/keystores/filters/TestRFC2254CertificateFilter.java
+++ b/afirma-keystores-filters/src/test/java/es/gob/afirma/keystores/filters/TestRFC2254CertificateFilter.java
@@ -4,8 +4,10 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
+import es.gob.afirma.core.misc.Platform;
 import es.gob.afirma.keystores.AOKeyStore;
 import es.gob.afirma.keystores.AOKeyStoreManager;
 import es.gob.afirma.keystores.AOKeyStoreManagerFactory;
@@ -41,6 +43,7 @@ public final class TestRFC2254CertificateFilter {
 	@Test
 	@SuppressWarnings("static-method")
 	public void TestRFC2254CertificateRecursiveFilter() throws Exception {
+		Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS());
 		final RFC2254CertificateFilter filter = new RFC2254CertificateFilter(null, "cn=ANF Global Root CA", true);  //$NON-NLS-1$
 		final AOKeyStoreManager ksm = AOKeyStoreManagerFactory.getAOKeyStoreManager(AOKeyStore.WINDOWS, null, "CAPI", null, null); //$NON-NLS-1$
 		final String[] aceptados = filter.matches(ksm.getAliases(), ksm);

--- a/afirma-keystores-mozilla/src/test/java/es/gob/afirma/keystores/mozilla/SimpleTest.java
+++ b/afirma-keystores-mozilla/src/test/java/es/gob/afirma/keystores/mozilla/SimpleTest.java
@@ -1,6 +1,7 @@
 package es.gob.afirma.keystores.mozilla;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.security.KeyStore;
@@ -10,6 +11,7 @@ import java.security.Signature;
 import java.util.Enumeration;
 import java.util.logging.Logger;
 
+import org.junit.Assume;
 import org.junit.Test;
 
 import es.gob.afirma.core.AOException;
@@ -91,6 +93,7 @@ public final class SimpleTest {
     @SuppressWarnings("static-method")
 	@Test
     public void testDirectNssUsage() throws Exception {
+    	Assume.assumeTrue(new File("C:\\Users\\tomas\\AppData\\Local\\Temp\\nss").exists()); //$NON-NLS-1$
     	final KeyStore keyStore = KeyStore.getInstance(
 			"PKCS11", //$NON-NLS-1$
 			loadNSS(


### PR DESCRIPTION
Corrige algunos test, evitando que se ejecuten en entornos donde van a fallar.
La mayoría de ellos son poner Assume.assumeTrue(Platform.OS.WINDOWS == Platform.getOS()) al principio para evitar que se ejecuten y fallen en Linux (tests específicos de windows).
Marcado con ignore un test que ya no se usa, y refactor a una manera más JUnit 4 de chequear excepciones.
