### PR TITLE
Mejora la búsqueda de librerías NSS y Sqlite en Linux

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -37,7 +37,7 @@ final class MozillaKeyStoreUtilitiesUnix {
 		"/usr/lib", //$NON-NLS-1$
 		"/usr/lib/nss", //$NON-NLS-1$
 		"/usr/lib/i386-linux-gnu/nss", /* En algunos Ubuntu y Debian 32 */ //$NON-NLS-1$
-		"/usr/lib/i386-linux-gnu/",  //$NON-NLS-1$
+		"/usr/lib/i386-linux-gnu",  //$NON-NLS-1$
 		"/opt/fedora-ds/clients/lib", //$NON-NLS-1$
 		"/opt/google/chrome", /* NSS de Chrome cuando no hay NSS de Mozilla de la misma arquitectura */ //$NON-NLS-1$
 		"/usr/lib/thunderbird", /* Si hay Thunderbird pero no Firefox */ //$NON-NLS-1$

--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -37,6 +37,7 @@ final class MozillaKeyStoreUtilitiesUnix {
 		"/usr/lib", //$NON-NLS-1$
 		"/usr/lib/nss", //$NON-NLS-1$
 		"/usr/lib/i386-linux-gnu/nss", /* En algunos Ubuntu y Debian 32 */ //$NON-NLS-1$
+		"/usr/lib/i386-linux-gnu/",  //$NON-NLS-1$
 		"/opt/fedora-ds/clients/lib", //$NON-NLS-1$
 		"/opt/google/chrome", /* NSS de Chrome cuando no hay NSS de Mozilla de la misma arquitectura */ //$NON-NLS-1$
 		"/usr/lib/thunderbird", /* Si hay Thunderbird pero no Firefox */ //$NON-NLS-1$


### PR DESCRIPTION
Mejora la búsqueda de las librerías permitiendo que estén en directorios diferentes.
Probado en Debian Sid, y en las Ubuntus mantenidas actualmente 16.10, 16.04, 14.04, 12.04.
