### PR TITLE
El configurador crea el certificado raiz en Linux y MacOSX

### DIFF
--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorLinux.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorLinux.java
@@ -14,6 +14,7 @@ final class ConfiguratorLinux implements Configurator {
     static final Logger LOGGER = Logger.getLogger("es.gob.afirma"); //$NON-NLS-1$
 
     private static final String KS_FILENAME = "autofirma.pfx"; //$NON-NLS-1$
+    private static final String FILE_AUTOFIRMA_CERTIFICATE = "AutoFirma_ROOT.cer"; //$NON-NLS-1$
     private static final String KS_PASSWORD = "654321"; //$NON-NLS-1$
     static final String EXPORT_PATH = "export PATH=$PATH:"; //$NON-NLS-1$
     static final String EXPORT_LD_LIBRARY ="export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"; //$NON-NLS-1$
@@ -36,10 +37,16 @@ final class ConfiguratorLinux implements Configurator {
             );
 
             LOGGER.info(Messages.getString("ConfiguratorLinux.11")); //$NON-NLS-1$
-
+            
+           //Generacion del certificado pfx
             ConfiguratorUtil.installFile(certPack.getPkcs12(), new File(
             		ConfiguratorUtil.getApplicationDirectory(), KS_FILENAME));
 
+          //Generacion del certificado raiz .cer
+            ConfiguratorUtil.installFile(
+            		certPack.getCaCertificate().getEncoded(), 
+            		new File(ConfiguratorUtil.getApplicationDirectory(), FILE_AUTOFIRMA_CERTIFICATE));
+            
             // comando para sacar los usuarios del sistema
             final String[] command = new String[] {
     				"cut", //$NON-NLS-1$

--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorMacOSX.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorMacOSX.java
@@ -90,7 +90,11 @@ final class ConfiguratorMacOSX implements Configurator {
 				certPack.getPkcs12(),
 				new File(ConfiguratorUtil.getApplicationDirectory(), KS_FILENAME)
 			);
-
+	          //Generacion del certificado raiz .cer
+            ConfiguratorUtil.installFile(
+            		certPack.getCaCertificate().getEncoded(), 
+            		new File(ConfiguratorUtil.getApplicationDirectory(), MACOSX_CERTIFICATE));
+            
 			window.print(Messages.getString("ConfiguratorMacOSX.6")); //$NON-NLS-1$
 
 			// damos permisos al script


### PR DESCRIPTION
En el commit [https://github.com/ctt-gob-es/clienteafirma/commit/34d3f633e59207c8bae51a3d4f4a758964bdcf12](https://github.com/ctt-gob-es/clienteafirma/commit/34d3f633e59207c8bae51a3d4f4a758964bdcf12) se movió la generación del certificado de ConfiguratorFirefox a ConfiguratorWindows, para crear siempre el certificado aunque no hubiese instalación de Firefox.
Si se hace de esa manera, es necesario replicarlo también en ConfiguratorLinux y ConfiguratorMacOSX, que es lo que hace esta Pull Request