### PR TITLE
parsea el formato pkcs11.txt con una entrada por linea

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/shared/Pkcs11Txt.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/shared/Pkcs11Txt.java
@@ -46,34 +46,83 @@ final class Pkcs11Txt {
 			);
 			return new ArrayList<ModuleName>(0);
 		}
-		final List<ModuleName> ret = new ArrayList<ModuleName>();
-		final Reader fr = new FileReader(f);
-		final BufferedReader br = new BoundedBufferedReader(
-			fr,
-			512, // Maximo 512 lineas
-			4096 // Maximo 4KB por linea
-		);
-	    String line;
-	    while ((line = br.readLine()) != null) {
-	    	final String lib = AOUtil.getRDNvalueFromLdapName("library", line.replace(" ", ",")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-	    	if (lib != null && !lib.trim().isEmpty()) {
-	    		ret.add(
-    				new ModuleName(
-						lib.trim(),
-						line.substring(
-								   line.indexOf(NAME_SEARCH_TOKEN) + NAME_SEARCH_TOKEN.length(),
-								   line.indexOf(
-									   '"',
-									   line.indexOf(NAME_SEARCH_TOKEN) + NAME_SEARCH_TOKEN.length()
-								   )
-							   )
-					)
-				);
-	    	}
-	    }
-	    br.close();
-	    fr.close();
+		final List<ModuleName> ret = getModules(f);
 	    return ret;
+	}
+
+	static List<ModuleName> getModules(final File f)	throws  IOException {
+		
+		Reader fr = null;
+		try {
+			fr = new FileReader(f);
+			final List<ModuleName> ret = getModules(fr);
+			return ret;
+		}
+		finally {
+			if (fr != null) {
+				fr.close();
+			}
+		}		
+	}
+
+  static List<ModuleName> getModules(final Reader fr)
+			throws IOException {
+		final List<ModuleName> ret = new ArrayList<ModuleName>();
+		BufferedReader br = null;		
+		try {
+			br = new BoundedBufferedReader(
+				fr,
+				512, // Maximo 512 lineas
+				4096 // Maximo 4KB por linea
+			);
+		    String line;
+		    String foundLib = null;
+		    String foundName = null;
+		    while ((line = br.readLine()) != null) {
+		    	if (line.trim().isEmpty()) {
+		    		// Una linea en blanco es una nueva sección
+		    		foundLib = null;
+		    		foundName = null;
+		    		continue;
+		    	}
+		    	final String lib = AOUtil.getRDNvalueFromLdapName("library", line.replace(" ", ",")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		    	if (lib != null && !lib.trim().isEmpty()) {
+		    		if (line.contains(NAME_SEARCH_TOKEN)) {
+			    		ret.add(
+		    				new ModuleName(
+								lib.trim(),
+								line.substring(
+										   line.indexOf(NAME_SEARCH_TOKEN) + NAME_SEARCH_TOKEN.length(),
+										   line.indexOf(
+											   '"',
+											   line.indexOf(NAME_SEARCH_TOKEN) + NAME_SEARCH_TOKEN.length()
+										   )
+									   )
+							)
+						);
+			    		foundLib = null;
+			    		foundName = null;
+		    		}
+		    		else {
+		    			foundLib = lib.trim();
+		    		}
+		    	}
+		    	else if (line.startsWith("name=")){
+		    		foundName = line.substring("name=".length()).trim();
+		    	}
+		    	if (foundLib != null && foundName != null && !foundLib.isEmpty() && !foundName.isEmpty()){
+		    		ret.add(new ModuleName(foundLib, foundName));
+		    		foundLib = null;
+		    		foundName = null;
+		    	}
+		    }
+		}
+		finally {
+			if (br != null) {
+				br.close();
+			}
+		}
+		return ret;
 	}
 
 }

--- a/afirma-keystores-mozilla/src/test/java/es/gob/afirma/keystores/mozilla/shared/TestNssSharedDb.java
+++ b/afirma-keystores-mozilla/src/test/java/es/gob/afirma/keystores/mozilla/shared/TestNssSharedDb.java
@@ -3,11 +3,15 @@ package es.gob.afirma.keystores.mozilla.shared;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import es.gob.afirma.core.misc.AOUtil;
 import es.gob.afirma.core.misc.BoundedBufferedReader;
+import es.gob.afirma.keystores.mozilla.AOSecMod.ModuleName;
 
 /** Pruebas de la configuraci&oacute;n especial de NSS compartido.
  * @author Tom&aacute;s Garc&iacute;a-Mer&aacute;s. */
@@ -44,6 +48,57 @@ public final class TestNssSharedDb {
 		   );
 	    }
 	    br.close();
+	}
+	
+	
+	@Test
+	public void testRawPkcs11txtFunction() throws Exception {
+		final byte[] pkcs11Txt = AOUtil
+				.getDataFromInputStream(TestNssSharedDb.class
+						.getResourceAsStream("/pkcs11.txt") //$NON-NLS-1$
+				);
+		Reader reader = null;
+		try {
+			reader = new InputStreamReader(new ByteArrayInputStream(pkcs11Txt));
+			List<ModuleName> modules = Pkcs11Txt.getModules(reader);
+			Assert.assertEquals(3, modules.size());
+			Assert.assertEquals(
+					"DataKey SignaSURE 3600 (EXTERNAL, dkck32.dll, slot 0)",
+					modules.get(0).toString());
+			Assert.assertEquals(
+					"Netscape Software Fortezza (EXTERNAL, swft32.dll, slot 0)",
+					modules.get(1).toString());
+			Assert.assertEquals(
+					"Litronic Netsign (EXTERNAL, core32.dll, slot 0)", modules
+							.get(2).toString());
+
+		} finally {
+			if (reader != null) {
+				reader.close();
+			}
+		}
+	}
+	
+	@Test
+	public void testRawPkcs11txtTest2() throws Exception {
+		final byte[] pkcs11Txt = AOUtil
+				.getDataFromInputStream(TestNssSharedDb.class
+						.getResourceAsStream("/pkcs11-test2.txt") //$NON-NLS-1$
+				);
+		Reader reader = null;
+		try {
+			reader = new InputStreamReader(new ByteArrayInputStream(pkcs11Txt));
+			List<ModuleName> modules = Pkcs11Txt.getModules(reader);
+			Assert.assertEquals(1, modules.size());
+			Assert.assertEquals(
+					"Mozilla Root Certs (EXTERNAL, /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so, slot 0)",
+					modules.get(0).toString());
+
+		} finally {
+			if (reader != null) {
+				reader.close();
+			}
+		}
 	}
 
 

--- a/afirma-keystores-mozilla/src/test/resources/pkcs11-test2.txt
+++ b/afirma-keystores-mozilla/src/test/resources/pkcs11-test2.txt
@@ -1,0 +1,8 @@
+library=
+name=NSS Internal PKCS #11 Module
+parameters=configdir='sql:/HOME/.pki/nssdb' certPrefix='' keyPrefix='' secmod='secmod.db' flags=optimizeSpace updatedir='' updateCertPrefix='' updateKeyPrefix='' updateid='' updateTokenDescription='' 
+NSS=Flags=internal,critical trustOrder=75 cipherOrder=100 slotParams=(1={slotFlags=[RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] askpw=any timeout=30})
+
+library=/usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
+name=Mozilla Root Certs
+NSS=trustOrder=100    


### PR DESCRIPTION
En sistemas Linux a veces aparece el pkcs11.txt con un formato distinto al esperado, con un elemento por linea.
Se cambia el parseador del fichero para que reonozca este nuevo formato (funciona también con el anterior).
Se adjunta test y archivo de ejemplo.
