### PR TITLE
Corregido error al firmar con AutoFirma documentos grandes cuando en …

### DIFF
--- a/afirma-ui-miniapplet-deploy/src/main/webapp/js/miniapplet.js
+++ b/afirma-ui-miniapplet-deploy/src/main/webapp/js/miniapplet.js
@@ -2004,6 +2004,7 @@ var MiniApplet = ( function ( window, undefined ) {
 
 				if (dataB64 != null && !isValidUrl(dataB64)) {
 					dataB64 = dataB64.replace(/\+/g, "-").replace(/\//g, "_");
+					dataB64 = dataB64.replace(/\n/g, "").replace(/\r/g, ""); //eliminamos saltos de carro para que no generen espacios 0x20 al parsear los atributos del XML enviado/recibido (storageServletAddress y retrieverServletAddress) que impiden la firma en AutoFirma
 				}
 
 				var idSession = generateNewIdSession();
@@ -2061,6 +2062,7 @@ var MiniApplet = ( function ( window, undefined ) {
 
 				if (dataB64 != null && !isValidUrl(dataB64)) {
 					dataB64 = dataB64.replace(/\+/g, "-").replace(/\//g, "_");
+					dataB64 = dataB64.replace(/\n/g, "").replace(/\r/g, ""); //eliminamos saltos de carro para que no generen espacios 0x20 al parsear los atributos del XML enviado/recibido (storageServletAddress y retrieverServletAddress) que impiden la firma en AutoFirma
 				}
 
 				var idSession = generateNewIdSession();
@@ -2115,6 +2117,7 @@ var MiniApplet = ( function ( window, undefined ) {
 
 				if (batchB64 != null && !isValidUrl(batchB64)) {
 					batchB64 = batchB64.replace(/\+/g, "-").replace(/\//g, "_");
+					batchB64 = batchB64.replace(/\n/g, "").replace(/\r/g, ""); //eliminamos saltos de carro para que no generen espacios 0x20 al parsear los atributos del XML enviado/recibido (storageServletAddress y retrieverServletAddress) que impiden la firma en AutoFirma
 				}
 
 				var idSession = generateNewIdSession();


### PR DESCRIPTION
…los datos codificados en Base64 existen saltos de línea.

Descripción del problema detectado en Port@firmas usando Autofirma en Android, pero que puede reproducirse en PC si se acaba usando el parámetro "rtservlet" al invocar Autofirma:

En los datos enviados/recibidos a/desde StorageServer/RetrieverServer, cifrados con DES, se envía un XML que contiene en un elemento <e k="dat" v="..."/> el documento a firmar en formato Base64 y dicho Base64 podría contener saltos de línea (como sucede en Port@firmas al usar es.juntadeandalucia.cice.pfirma.business.DescargaFicheroServlet, que devuelve un documento generado por es.juntadeandalucia.cice.pfirma.business.SignBO.appendBase64Document(..)). 

es.gob.afirma.core.misc.protocol.ProtocolInvocationUriParserUtil.parseXml analiza el XML y, siguiendo las directivas de https://www.w3.org/TR/1998/REC-xml-19980210#AVNormalize, sustituye los saltos de carro por espacios (0x20) en los atributos de un elemento XML (el atributo "v"). 

En estos casos es.gob.afirma.core.misc.Base64.isBase64(...) devuelve "false" al detectar un 0x20 en el código Base64 al no estar incluido en la cadena de la constante BASE_64_ALPHABET. Este método isBase64(...) es invocado por AutoFirma en es.gob.afirma.core.misc.http.DataDownloader.downloadData(String), invocado a su vez en es.gob.afirma.core.misc.protocol.UrlParameters.setCommonParameters(Map<String, String>), y al no corresponderse con ningún formato de cadena conocida, no la trata y la devuelve sin decodificar (devuelve el Base64 en lugar del documento original), lo que genera errores en el proceso de firma.
