### PR TITLE
Corrección de PdfUtil.java para que se puedan firmar PDFs previamente…

### DIFF
--- a/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
+++ b/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
@@ -169,7 +169,7 @@ public final class PdfUtil {
 	static void checkPdfCertification(final int pdfCertificationLevel, final Properties extraParams) throws PdfIsCertifiedException {
 		if (pdfCertificationLevel != PdfSignatureAppearance.NOT_CERTIFIED &&
 				!Boolean.parseBoolean(extraParams.getProperty(PdfExtraParams.ALLOW_SIGNING_CERTIFIED_PDFS))) {
-			// Si no permitimos dialogos graficos o directamente hemos indicado que no permitimos firmar PDF certificados lanzamos
+			// Si no permitimos dialogos graficos lanzamos
 			// una excepcion
 			if (Boolean.parseBoolean(extraParams.getProperty(PdfExtraParams.HEADLESS))) {
 				throw new PdfIsCertifiedException();

--- a/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
+++ b/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
@@ -171,7 +171,7 @@ public final class PdfUtil {
 				!Boolean.parseBoolean(extraParams.getProperty(PdfExtraParams.ALLOW_SIGNING_CERTIFIED_PDFS))) {
 			// Si no permitimos dialogos graficos o directamente hemos indicado que no permitimos firmar PDF certificados lanzamos
 			// una excepcion
-			if (Boolean.parseBoolean(extraParams.getProperty(PdfExtraParams.HEADLESS)) || "false".equalsIgnoreCase(extraParams.getProperty(PdfExtraParams.ALLOW_SIGNING_CERTIFIED_PDFS))) {  //$NON-NLS-1$
+			if (Boolean.parseBoolean(extraParams.getProperty(PdfExtraParams.HEADLESS))) {
 				throw new PdfIsCertifiedException();
 			}
 			// En otro caso, perguntamos al usuario

--- a/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
+++ b/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
@@ -170,7 +170,7 @@ public final class PdfUtil {
 		if (pdfCertificationLevel != PdfSignatureAppearance.NOT_CERTIFIED &&
 				!Boolean.parseBoolean(extraParams.getProperty(PdfExtraParams.ALLOW_SIGNING_CERTIFIED_PDFS))) {
 			// Si no permitimos dialogos graficos lanzamos
-			// una excepcion
+			// una excepcion (en otro caso, preguntaremos al usuario tras este if)
 			if (Boolean.parseBoolean(extraParams.getProperty(PdfExtraParams.HEADLESS))) {
 				throw new PdfIsCertifiedException();
 			}


### PR DESCRIPTION
… certificados que admitan firmas

Sin esta corrección, autofirma da error al intentar firmar un PDF previamente certificado que permite firmas.

Con esta corrección, autofirma permitirá firmar PDFs previamente certificados que permitan firmas.