### PR TITLE
Firma XAdES internally Detached falla

### DIFF
--- a/afirma-ui-miniapplet-deploy/src/main/webapp/js/miniapplet.js
+++ b/afirma-ui-miniapplet-deploy/src/main/webapp/js/miniapplet.js
@@ -1210,7 +1210,7 @@ var MiniApplet = ( function ( window, undefined ) {
 					dataB64 = null;
 				}
 
-				if (dataB64 != null && !isValidUrl(dataB64)) {
+				if (dataB64 != null && !isValidUrl(dataB64)  && format!="XAdES") {
 					dataB64 = dataB64.replace(/\+/g, "-").replace(/\//g, "_");
 				}
 


### PR DESCRIPTION
Está ocurriendo un problema con el miniapplet y Autofirma al realizar una firma XAdES internally Detached de un XML. Hemos modificado el fichero miniapplet.js para que no escape los carácteres / por _ para que en el caso que el parámetro format tenga valor Xades no haga esto. Tras esa modificación el funcionamiento ha sido correcto.