### PR TITLE
Soporte para firma de formatos OOXML y ODF desde línea de comandos

### DIFF
--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/CommandLineLauncher.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/CommandLineLauncher.java
@@ -47,6 +47,8 @@ import es.gob.afirma.keystores.filters.CertFilterManager;
 import es.gob.afirma.keystores.filters.CertificateFilter;
 import es.gob.afirma.signers.batch.client.BatchSigner;
 import es.gob.afirma.signers.cades.AOCAdESSigner;
+import es.gob.afirma.signers.odf.AOODFSigner;
+import es.gob.afirma.signers.ooxml.AOOOXMLSigner;
 import es.gob.afirma.signers.pades.AOPDFSigner;
 import es.gob.afirma.signers.xades.AOFacturaESigner;
 import es.gob.afirma.signers.xades.AOXAdESSigner;
@@ -491,7 +493,8 @@ final class CommandLineLauncher {
 		String format = null;
 		Properties extraParamsProperties = null;
 		if (command != CommandLineCommand.MASSIVE) {
-			// Si el formato es "auto", miramos si es XML o PDF para asignar XAdES o PAdES
+			/* Si el formato es "auto", miramos si es XML o PDF para asignar XAdES o PAdES,
+			   Office para asignar OOXML, OpenOffice para asignar ODF */
 			if (CommandLineParameters.FORMAT_AUTO.equals(fmt)) {
 				final String ext = new MimeHelper(data).getExtension();
 				if ("pdf".equals(ext)) { //$NON-NLS-1$
@@ -499,6 +502,14 @@ final class CommandLineLauncher {
 				}
 				else if ("xml".equals(ext)) { //$NON-NLS-1$
 					format = CommandLineParameters.FORMAT_XADES;
+				}
+				else if("docx".equals(ext) || "xlsx".equals(ext) || "pptx".equals(ext))
+				{
+					format = CommandLineParameters.FORMAT_OOXML;					
+				}
+				else if("odt".equals(ext) || "ods".equals(ext) || "odp".equals(ext))
+				{
+					format = CommandLineParameters.FORMAT_ODF;					
 				}
 				else {
 					format = CommandLineParameters.FORMAT_CADES;
@@ -553,6 +564,12 @@ final class CommandLineLauncher {
 		}
 		else if (CommandLineParameters.FORMAT_FACTURAE.equals(format)) {
 			signer = new AOFacturaESigner();
+		}
+		else if (CommandLineParameters.FORMAT_OOXML.equals(format)) {
+			signer = new AOOOXMLSigner();
+		}
+		else if (CommandLineParameters.FORMAT_ODF.equals(format)) {
+			signer = new AOODFSigner();
 		}
 		else {
 			throw new CommandLineException(CommandLineMessages.getString("CommandLineLauncher.4", format)); //$NON-NLS-1$

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/CommandLineParameters.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/CommandLineParameters.java
@@ -38,6 +38,8 @@ final class CommandLineParameters {
 	public static final String FORMAT_PADES    = "pades"; //$NON-NLS-1$
 	public static final String FORMAT_CADES    = "cades"; //$NON-NLS-1$
 	public static final String FORMAT_FACTURAE = "facturae"; //$NON-NLS-1$
+	public static final String FORMAT_OOXML = "ooxml"; //$NON-NLS-1$
+	public static final String FORMAT_ODF = "odf"; //$NON-NLS-1$
 	public static final String DEFAULT_FORMAT  = FORMAT_AUTO;
 
 	public static final String MASSIVE_OP_SIGN			= "sign"; //$NON-NLS-1$
@@ -190,7 +192,10 @@ final class CommandLineParameters {
 				if (!this.format.equals(FORMAT_XADES) &&
 						!this.format.equals(FORMAT_CADES) &&
 						!this.format.equals(FORMAT_PADES) &&
-						!this.format.equals(FORMAT_FACTURAE)) {
+						!this.format.equals(FORMAT_FACTURAE) &&
+						!this.format.equals(FORMAT_OOXML) &&
+						!this.format.equals(FORMAT_ODF) && 
+						!this.format.equals(FORMAT_AUTO)) {
 					throw new CommandLineException(CommandLineMessages.getString("CommandLineLauncher.4", params[i + 1])); //$NON-NLS-1$
 				}
 				i++;
@@ -328,6 +333,8 @@ final class CommandLineParameters {
 			.append("  \t ").append(FORMAT_PADES).append("\t\t (").append(CommandLineMessages.getString("CommandLineLauncher.44")).append(")\n") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			.append("  \t ").append(FORMAT_XADES).append("\t\t (").append(CommandLineMessages.getString("CommandLineLauncher.45")).append(")\n") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			.append("  \t ").append(FORMAT_FACTURAE).append("\t (").append(CommandLineMessages.getString("CommandLineLauncher.46")).append(")\n") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			.append("  \t ").append(FORMAT_OOXML).append("\t\t (").append(CommandLineMessages.getString("CommandLineLauncher.72")).append(")\n") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			.append("  \t ").append(FORMAT_ODF).append("\t\t (").append(CommandLineMessages.getString("CommandLineLauncher.73")).append(")\n") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			.append("  ").append(PARAM_CONFIG).append(" extraParams\t (").append(CommandLineMessages.getString("CommandLineLauncher.27")).append(")\n")  //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			.append("  ").append(PARAM_STORE).append("\t\t (").append(CommandLineMessages.getString("CommandLineLauncher.31")).append(")\n") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			.append("  \t auto\t\t (").append(CommandLineMessages.getString("CommandLineLauncher.36")).append(")\n") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/afirma-simple/src/main/resources/properties/commandlinemessages.properties
+++ b/afirma-simple/src/main/resources/properties/commandlinemessages.properties
@@ -68,5 +68,7 @@ CommandLineLauncher.69=firma/multifirma de lotes de ficheros
 CommandLineLauncher.7=Sintaxis
 CommandLineLauncher.70=creacion de huella digitales con interfaz grafica
 CommandLineLauncher.71=comprobacion de huella digitales con interfaz grafica
+CommandLineLauncher.72=Formato OOXML
+CommandLineLauncher.73= Formato ODF
 CommandLineLauncher.8=firma de fichero
 CommandLineLauncher.9=cofirma de fichero

--- a/afirma-simple/src/main/resources/properties/commandlinemessages.properties
+++ b/afirma-simple/src/main/resources/properties/commandlinemessages.properties
@@ -69,6 +69,6 @@ CommandLineLauncher.7=Sintaxis
 CommandLineLauncher.70=creacion de huella digitales con interfaz grafica
 CommandLineLauncher.71=comprobacion de huella digitales con interfaz grafica
 CommandLineLauncher.72=Formato OOXML
-CommandLineLauncher.73= Formato ODF
+CommandLineLauncher.73=Formato ODF
 CommandLineLauncher.8=firma de fichero
 CommandLineLauncher.9=cofirma de fichero


### PR DESCRIPTION
El programa AutoFirma utilizado a través de la línea de comandos (AutoFirmaCommandLine) no permite firmar ficheros de tipo OOXML (.docx, .xlsx, .pptx), ni tampoco ficheros de tipo ODF (.odt, .ods, .odp). En cambio, desde la interfaz gráfica del programa AutoFirma, la firma de este tipo de ficheros sí que está permitida, por lo que se han realizado los cambios oportunos para permitir la firma de este tipo de ficheros también a través de la línea de comandos.

Para ello, se han añadido dos nuevos valores a los ya existentes que se pueden utilizar con el parámetro -format: **ooxml** y **odf**.

De esta manera, si quisiéramos firmar un documento .docx desde línea de comandos, deberíamos invocarlo de la siguiente forma:
AutoFirmaCommandLine sign -i "C:\autofirma\docs-pruebas\test.docx" -o "C:\autofirma\docs-pruebas-output\test-signed.docx" -algorithm SHA256withRSA **-format ooxml** -store "pkcs12:C:\test\micertificado.p12" -password "mipassword" -alias "mialias"

Para firmar un documento .odt:
AutoFirmaCommandLine sign -i "C:\autofirma\docs-pruebas\test.odt" -o "C:\autofirma\docs-pruebas-output\test-signed.odt" -algorithm SHA256withRSA **-format odf** -store "pkcs12:C:\test\micertificado.p12" -password "mipassword" -alias "mialias"

Por último, se ha añadido soporte para que se puedan firmar ficheros de tipo ooxml y odf pasando el valor auto al parámetro format:

AutoFirmaCommandLine sign -i "C:\autofirma\docs-pruebas\test.docx" -o "C:\autofirma\docs-pruebas-output\test-signed.docx" -algorithm SHA256withRSA **-format auto** -store "pkcs12:C:\test\micertificado.p12" -password "mipassword" -alias "mialias"

Para el caso de la contrafirma que no está soportada para los formatos OOXML y ODF, la actual implementación de la firma ya controla que no se pueda realizar y devuelve el mensaje de error oportuno.