### PR TITLE
Arregla los paths de NSS para Unix multilib

### DIFF
--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/Platform.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/Platform.java
@@ -254,7 +254,28 @@ public final class Platform {
 
             return systemRoot + "System32"; //$NON-NLS-1$
         }
-        return "/usr/lib"; //$NON-NLS-1$
+
+        // ALL UNIX VARIANTS FOLLOWING FHS
+        // There are, generally, two kind of Unix flavours:
+        // a) Those whose libdir has explicit bit set: /usr/lib64 or /usr/lib32
+        // b) Those whose libdir does not include it: /usr/lib
+        //
+        // In the case of X bits and /usr/libX exists, it is clear that we
+        // are safe.
+        // In the case of X bits and /usr/libX does not exist, it is probably
+        // due to either the case:
+        //     Platform is 64, and folders /usr/lib and /usr/lib32 exist
+        // or
+        //     Platform is 32, and folders /usr/lib and /usr/lib64 exist
+        //
+        // In any case, the *safe* route is to first try the a) case before b).
+
+        final String canonicalLibDir = "/usr/lib" + Platform.getJavaArch(); // $NON-NLS-1$
+        if (new File(canonicalLibDir).exists()) {
+            return canonicalLibDir;
+        } else {
+            return "/usr/lib"; //$NON-NLS-1$
+        }
     }
 
 }

--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
@@ -404,8 +404,11 @@ public final class MozillaKeyStoreUtilities {
 		final String dependList[];
 
 		// Compobamos despues el caso especifico de NSS partido entre /usr/lib y
-		// /lib, que se da en Fedora
-		if (Platform.OS.LINUX.equals(Platform.getOS()) && new File("/usr/lib/" + SOFTOKN3_SO).exists() && new File(LIB_NSPR4_SO).exists()) { //$NON-NLS-1$
+		// /lib, que se da en versiones de Fedora muy antiguas y solo en 32 bits
+		if (Platform.OS.LINUX.equals(Platform.getOS())
+                && "32".equals(Platform.getJavaArch())
+                && new File("/usr/lib/" + SOFTOKN3_SO).exists()
+                && new File(LIB_NSPR4_SO).exists()) { //$NON-NLS-1$
 			dependList = new String[] {
 					"/lib/libmozglue.so", //$NON-NLS-1$
 					"/usr/lib/libmozglue.so", //$NON-NLS-1$

--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
@@ -750,20 +750,9 @@ public final class MozillaKeyStoreUtilities {
 		// En sistema operativo extrano devulevo cadena vacia
 		if (!Platform.OS.WINDOWS.equals(Platform.getOS())) {
 			return ""; //$NON-NLS-1$
-		}
-		final String winDir = System.getenv("SystemRoot"); //$NON-NLS-1$
-		if (winDir == null) {
-			return ""; //$NON-NLS-1$
-		}
-		// Si java es 64 bits, no hay duda de que Windows es 64 bits y buscamos bibliotecas
-		// de 64 bits
-		if ("64".equals(Platform.getJavaArch())) { //$NON-NLS-1$
-			return winDir + "\\System32\\";  //$NON-NLS-1$
-		}
-		if (new File(winDir + "\\SysWOW64\\").exists()) { //$NON-NLS-1$
-			return winDir + "\\SysWOW64\\"; //$NON-NLS-1$
-		}
-		return winDir + "\\System32\\"; //$NON-NLS-1$
+		} else {
+		    return Platform.getSystemLibDir() + "\\";
+        }
 	}
 
 	private static boolean isModuleIncluded(final Map<String, String> externalStores, final String moduleName) {

--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
@@ -406,9 +406,9 @@ public final class MozillaKeyStoreUtilities {
 		// Compobamos despues el caso especifico de NSS partido entre /usr/lib y
 		// /lib, que se da en versiones de Fedora muy antiguas y solo en 32 bits
 		if (Platform.OS.LINUX.equals(Platform.getOS())
-                && "32".equals(Platform.getJavaArch())
-                && new File("/usr/lib/" + SOFTOKN3_SO).exists()
-                && new File(LIB_NSPR4_SO).exists()) { //$NON-NLS-1$
+                && "32".equals(Platform.getJavaArch()) //$NON-NLS-1$
+                && new File("/usr/lib/" + SOFTOKN3_SO).exists() //$NON-NLS-1$
+                && new File(LIB_NSPR4_SO).exists()) {
 			dependList = new String[] {
 					"/lib/libmozglue.so", //$NON-NLS-1$
 					"/usr/lib/libmozglue.so", //$NON-NLS-1$
@@ -754,7 +754,7 @@ public final class MozillaKeyStoreUtilities {
 		if (!Platform.OS.WINDOWS.equals(Platform.getOS())) {
 			return ""; //$NON-NLS-1$
 		} else {
-		    return Platform.getSystemLibDir() + "\\";
+		    return Platform.getSystemLibDir() + "\\"; //$NON-NLS-1$
         }
 	}
 

--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -9,12 +9,11 @@
 
 package es.gob.afirma.keystores.mozilla;
 
+import es.gob.afirma.core.misc.Platform;
+
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Logger;
 
 final class MozillaKeyStoreUtilitiesUnix {
@@ -23,24 +22,7 @@ final class MozillaKeyStoreUtilitiesUnix {
 
 	private static final String SOFTOKN3_SO = "libsoftokn3.so"; //$NON-NLS-1$
 
-	private static final String[] NSS_PATHS = new String[] {
-		"/usr/lib/x86_64-linux-gnu/nss", // Debian 64 //$NON-NLS-1$
-		"/usr/lib/x86_64-linux-gnu/",  //$NON-NLS-1$
-		"/usr/lib/firefox", //$NON-NLS-1$
-		"/usr/lib/firefox-" + searchLastFirefoxVersion("/usr/lib/"), //$NON-NLS-1$ //$NON-NLS-2$
-		"/opt/firefox", //$NON-NLS-1$
-		"/opt/firefox-" + searchLastFirefoxVersion("/opt/"), //$NON-NLS-1$ //$NON-NLS-2$
-		"/lib", //$NON-NLS-1$
-		"/usr/lib64", //$NON-NLS-1$
-		"/usr/lib", //$NON-NLS-1$
-		"/usr/lib/nss", //$NON-NLS-1$
-		"/usr/lib/i386-linux-gnu/nss", /* En algunos Ubuntu y Debian 32 */ //$NON-NLS-1$
-		"/usr/lib/i386-linux-gnu",  //$NON-NLS-1$
-		"/opt/fedora-ds/clients/lib", //$NON-NLS-1$
-		"/opt/google/chrome", /* NSS de Chrome cuando no hay NSS de Mozilla de la misma arquitectura */ //$NON-NLS-1$
-		"/usr/lib/thunderbird", /* Si hay Thunderbird pero no Firefox */ //$NON-NLS-1$
-		"/usr/lib64", /* NSS cuando solo hay Firefox de 64 en el sistema */ //$NON-NLS-1$
-	};
+	private static final String[] NSS_PATHS = getNssPaths();
 
 	private static final String[] SQLITE_LIBS = {
 		"mozsqlite3.so",  //$NON-NLS-1$
@@ -51,6 +33,49 @@ final class MozillaKeyStoreUtilitiesUnix {
 
 	private MozillaKeyStoreUtilitiesUnix() {
 		// No instanciable
+	}
+
+	private static String[] getNssPaths() {
+		final List<String> nssPaths = new ArrayList<>();
+		final String javaArch = Platform.getJavaArch();
+		final String systemLibDir = Platform.getSystemLibDir();
+
+		if("64".equals(javaArch)) { //$NON-NLS-1$
+			nssPaths.add("/usr/lib/x86_64-linux-gnu/nss"); //$NON-NLS-1$
+			nssPaths.add("/usr/lib/x86_64-linux-gnu"); //$NON-NLS-1$
+		} else if("32".equals(javaArch)) { //$NON-NLS-1$
+			nssPaths.add("/usr/lib/i386-linux-gnu/nss"); /* En algunos Ubuntu y Debian 32 */ //$NON-NLS-1$
+			nssPaths.add("/usr/lib/i386-linux-gnu"); //$NON-NLS-1$
+		}
+
+		nssPaths.add(systemLibDir + "/nss"); //$NON-NLS-1$
+		nssPaths.add(systemLibDir); //$NON-NLS-1$
+		nssPaths.add(systemLibDir + "/firefox"); //$NON-NLS-1$
+
+		// Preserve backwards-compatibility on https://github.com/ctt-gob-es/clienteafirma/issues/27#issuecomment-488402089
+		nssPaths.add(systemLibDir + "/firefox-");  //$NON-NLS-1$
+		nssPaths.add(systemLibDir + "/thunderbird"); //$NON-NLS-1$
+
+		if(new File("/lib" + javaArch).isDirectory()) { //$NON-NLS-1$
+			nssPaths.add("/lib" + javaArch); //$NON-NLS-1$
+		} else {
+			nssPaths.add("/lib"); //$NON-NLS-1$
+		}
+
+		nssPaths.add("/opt/firefox"); //$NON-NLS-1$
+
+		// Preserve backwards-compatibility on https://github.com/ctt-gob-es/clienteafirma/issues/27#issuecomment-488402089
+		nssPaths.add("/opt/firefox-"); //$NON-NLS-1$
+
+		nssPaths.add("/opt/fedora-ds/clients/lib"); //$NON-NLS-1$
+		nssPaths.add("/opt/google/chrome"); /* NSS de Chrome cuando no hay NSS de Mozilla de la misma arquitectura */ //$NON-NLS-1$
+
+		for(int i = nssPaths.size() - 1; i >= 0; i--) {
+			if(!new File(nssPaths.get(i)).isDirectory()) {
+				nssPaths.remove(i);
+			}
+		}
+		return nssPaths.toArray(new String[0]);
 	}
 
 	static String getNSSLibDirUnix() throws FileNotFoundException {
@@ -87,50 +112,4 @@ final class MozillaKeyStoreUtilitiesUnix {
 			"No se ha podido determinar la localizacion de NSS en UNIX (sqlite)" //$NON-NLS-1$
 		);
 	}
-
-	/** Busca la &uacute;ltima versi&oacute;n de Firefox instalada en un sistema
-	 * Linux o Solaris.
-	 * @param startDir Directorio de inicio para la b&uacute;squeda.
-	 * @return &Uacute;ltima versi&oacute;n instalada en el sistema. */
-	private static String searchLastFirefoxVersion(final String startDir) {
-		final File directoryLib = new File(startDir);
-		if (directoryLib.isDirectory()) {
-			final String filenames[] = directoryLib.list();
-			final List<String> firefoxDirectories = new ArrayList<>();
-			if (filenames != null) {
-				for (final String filename : filenames) {
-					if (filename.startsWith("firefox-")) { //$NON-NLS-1$
-						firefoxDirectories.add(filename.replace("firefox-", "")); //$NON-NLS-1$ //$NON-NLS-2$
-					}
-				}
-			}
-			if (firefoxDirectories.isEmpty()) {
-				return ""; //$NON-NLS-1$
-			}
-			for (int i = 0; i < firefoxDirectories.size(); i++) {
-				try {
-					Integer.getInteger(firefoxDirectories.get(i));
-				}
-				catch (final Exception e) {
-					firefoxDirectories.remove(i);
-				}
-			}
-			if (firefoxDirectories.size() == 1) {
-				return firefoxDirectories.get(0);
-			}
-			Collections.sort(
-				firefoxDirectories,
-				new Comparator<String>() {
-					/** {@inheritDoc} */
-					@Override
-					public int compare(final String o1, final String o2) {
-						return o1.compareTo(o2);
-					}
-				}
-			);
-			return firefoxDirectories.get(0);
-		}
-		return ""; //$NON-NLS-1$
-	}
-
 }


### PR DESCRIPTION
Esta PR arregla #27.

Para hacerlo, se reescribe la lógica para obtener los `NSS_PATHS` de forma que ahora se tiene en cuenta al evaluarlos la primera vez si la arquitectura es de 32 o 64 bits, y se utilizan solo aquellos directorios que existen y en la arquitectura adecuada.

Esto debería de impedir la aparición de errores debidos al UnsatisfiedLinkError que se genera cuando en un sistema multilib se intenta cargar una biblioteca de 32 bits en un runtime de 64 bits.

Se soluciona todo lo que dice #27, incluyendo eliminar searchLastFirefoxVersion.

Esta función, sin tests unitarios, no funciona como se esperaría, y salvo en casos muy circunstanciales y no documentados (tener en la JVM una propiedad con el nombre igual a una ruta en la que se encuentre un Firefox y un valor de tipo entero), devolverá siempre la cadena vacía. Por esto, para eliminar deuda técnica, se elimina la función, que nunca tuvo más uso que utilizar la constante `""`.

Se mantiene, con el espíritu de no romper la compatibilidad hacia atrás, la opción de utilizar el caso de `/usr/lib/firefox-` (resultante del caso anterior, tras sustituir searchLastFirefoxVersion por su resultado), puesto qe este directorio sí podría haber sido utilizado en un entorno real.