### PR TITLE
Añadir soporte para la JVM de IBM

### DIFF
--- a/afirma-core-keystores/src/main/java/es/gob/afirma/keystores/KeyStoreUtilities.java
+++ b/afirma-core-keystores/src/main/java/es/gob/afirma/keystores/KeyStoreUtilities.java
@@ -356,6 +356,9 @@ public final class KeyStoreUtilities {
 				aksm.addKeyStoreManager(getDnieKeyStoreManager(parentComponent));
 				return true; // Si instancia esta tarjeta, no pruebo el resto. No deberia haber varias tarjetas insertadas
 			}
+            catch (final NoClassDefFoundError e) {
+                LOGGER.info("No se puede inicializar el almacén de tipo DNIe: " + e); //$NON-NLS-1$
+            }
 			catch (final AOCancelledOperationException e) {
 				throw e;
 			}
@@ -375,6 +378,9 @@ public final class KeyStoreUtilities {
 				aksm.addKeyStoreManager(getCeres430KeyStoreManager(parentComponent));
 				return true; // Si instancia esta tarjeta, no pruebo el resto. No deberia haber varias tarjetas insertadas
 			}
+            catch (final NoClassDefFoundError e) {
+                LOGGER.info("No se puede inicializar el almacén de tipo CERES 4.30 o superior: " + e); //$NON-NLS-1$
+            }
 			catch (final AOCancelledOperationException e) {
 				throw e;
 			}
@@ -387,6 +393,9 @@ public final class KeyStoreUtilities {
 				aksm.addKeyStoreManager(getCeresKeyStoreManager(parentComponent));
 				return true; // Si instancia esta tarjeta, no pruebo el resto. No deberia haber varias tarjetas insertadas
 			}
+            catch (final NoClassDefFoundError e) {
+                LOGGER.info("No se puede inicializar el almacén de tipo CERES (otras): " + e); //$NON-NLS-1$
+            }
 			catch (final AOCancelledOperationException e) {
 				throw e;
 			}
@@ -406,6 +415,9 @@ public final class KeyStoreUtilities {
 				aksm.addKeyStoreManager(getSmartCafeKeyStoreManager(parentComponent));
 				return true; // Si instancia SmartCafe no pruebo otras tarjetas, no deberia haber varias tarjetas instaladas
 			}
+            catch (final NoClassDefFoundError e) {
+                LOGGER.info("No se puede inicializar el almacén de tipo G&D SmartCafe: " + e); //$NON-NLS-1$
+            }
 			catch (final AOCancelledOperationException e) {
 				throw e;
 			}

--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/http/UrlHttpManagerImpl.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/http/UrlHttpManagerImpl.java
@@ -76,7 +76,6 @@ public class UrlHttpManagerImpl implements UrlHttpManager {
 	private static final String KEYSTORE_PASS = "javax.net.ssl.keyStorePassword"; //$NON-NLS-1$
 	private static final String KEYSTORE_TYPE = "javax.net.ssl.keyStoreType"; //$NON-NLS-1$
 	private static final String KEYSTORE_DEFAULT_TYPE = "JKS"; //$NON-NLS-1$
-	private static final String KEYMANAGER_INSTANCE = "SunX509";//$NON-NLS-1$
 	private static final String SSL_CONTEXT = "SSL";//$NON-NLS-1$
 
 	private static KeyStore sslKeyStore = null;
@@ -426,7 +425,7 @@ public class UrlHttpManagerImpl implements UrlHttpManager {
 			}
 			kstorePassword = keyStorePassword != null ? keyStorePassword.toCharArray() : new char[0];
 		}
-		final KeyManagerFactory keyFac = KeyManagerFactory.getInstance(KEYMANAGER_INSTANCE);
+		final KeyManagerFactory keyFac = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
 		keyFac.init(
 			kstore,
 			kstorePassword

--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilities.java
@@ -715,16 +715,23 @@ public final class MozillaKeyStoreUtilities {
 		// registro para evitar mostrar datos personales
 		LOGGER.info("Configuracion de NSS para SunPKCS11:\n" + p11NSSConfigFile.replace(Platform.getUserHome(), "USERHOME")); //$NON-NLS-1$ //$NON-NLS-2$
 
-		final Provider p = AOUtil.isJava9orNewer() ?
-			loadNssJava9(nssDirectory, p11NSSConfigFile) :
-				loadNssJava8(nssDirectory, p11NSSConfigFile);
+		try {
+			final Provider p = AOUtil.isJava9orNewer() ?
+				loadNssJava9(nssDirectory, p11NSSConfigFile) :
+					loadNssJava8(nssDirectory, p11NSSConfigFile);
 
-		Security.addProvider(p);
+			Security.addProvider(p);
 
-		LOGGER.info(
-			"Proveedor PKCS#11 para NSS anadido" + (useSharedNss ? " para perfil compartido" : "") + ": " + p.getName() //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		);
-		return p;
+			LOGGER.info(
+				"Proveedor PKCS#11 para NSS anadido" + (useSharedNss ? " para perfil compartido" : "") + ": " + p.getName() //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			);
+			return p;
+		} catch(final ClassNotFoundException e) {
+			LOGGER.warning(
+				"No se ha podido añadir el proveedor PKCS#11 para NSS" + (useSharedNss ? " para perfil compartido" : "") + ": " + e //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			);
+		}
+		return null;
 	}
 
 	private static boolean isDniePkcs11Library(final String driverName) {

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/CommandProcessorThread.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/CommandProcessorThread.java
@@ -529,8 +529,8 @@ class CommandProcessorThread extends Thread {
 			readingTries = 0;
 			do {
 				readingTries++;
-				socketIs.read(reqBuffer);
-				insert = new String(reqBuffer, StandardCharsets.UTF_8);
+				int bytesRead = socketIs.read(reqBuffer);
+				insert = new String(reqBuffer, 0, bytesRead, StandardCharsets.UTF_8);
 			} while (insert.trim().isEmpty() && readingTries <= MAX_READING_BUFFER_TRIES);
 
 			// Para evitar un error de memoria, si llegamos al maximo numero de intentos en el

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/SecureSocketUtils.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/SecureSocketUtils.java
@@ -24,7 +24,6 @@ class SecureSocketUtils {
 	private static final String CTPASS = "654321"; //$NON-NLS-1$
 	private static final String KEYSTORE_NAME = "autofirma.pfx"; //$NON-NLS-1$
 	private static final String PKCS12 = "PKCS12"; //$NON-NLS-1$
-	private static final String KEY_MANAGER_TYPE = "SunX509"; //$NON-NLS-1$
 	private static final String SSLCONTEXT = "TLSv1"; //$NON-NLS-1$
 
 	/**
@@ -51,8 +50,8 @@ class SecureSocketUtils {
 		try (InputStream is = new FileInputStream(sslKeyStoreFile)) {
 			ks.load(is, ksPass);
 		}
-		// key manager factory de tipo SunX509
-		final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KEY_MANAGER_TYPE);
+		// key manager factory por defecto (de tipo SunX509 en OpenJDK, o de tipo ibmX509 en IBM JVM)
+		final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
 		kmf.init(ks, ctPass);
 
 		final SSLContext sc = SSLContext.getInstance(SSLCONTEXT);


### PR DESCRIPTION
Este PR compatibiliza el cliente AutoFirma con la JVM versión SDK8 (last update: 8.0.6.0 – 27 November 2019), publicada en https://developer.ibm.com/javasdk/downloads/sdk8/

Se trata de los siguientes cambios:
1. Sustituir el uso del algoritmo 'SunX509' por el que esté definido por defecto en la JVM, que en el caso de IBM será 'ibmX509'.
2. Manejar la excepción de clase no encontrada cuando se intenta abrir el almacén NSS, debido a que se utiliza la clase `SunPKCS11` que no existe en la JVM de IBM.
3. Manejar el error de definición de clase no encontrada por no existir la excepción `javax.smartcardio.CardException`.
4. Se corrige un bug en el método de lectura de datos `read(...)` en `CommandProcessorThread`, por el cual no se está teniendo en cuenta la cantidad de bytes leídos, que provoca una lectura errónea si se utiliza la JVM de IBM.