### PR TITLE
Corregido enlace a la documentación real

### DIFF
--- a/afirma-simple-installer/linux/README.txt
+++ b/afirma-simple-installer/linux/README.txt
@@ -1,4 +1,4 @@
 Se pueden consultar las instrucciones para generar el instalador DEB de AutoFirma para Linux en el manual publicado en:
 
-https://github.com/ctt-gob-es/clienteafirma-docs/blob/master/AF_Firmar_AutoFirma_Linux.docx
+https://github.com/ctt-gob-es/clienteafirma-docs/blob/master/AF_Instalador%20Linux.docx
 


### PR DESCRIPTION
El fichero al que apuntaba para la documentación de instalación era incorrecto.