### PR TITLE
En algunos sistemas Linux devuelve os.arch como amd64

### DIFF
--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/Platform.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/Platform.java
@@ -106,7 +106,7 @@ public final class Platform {
     	if (osArch.equals("mips")) { //$NON-NLS-1$
     		return MACHINE.MIPS32;
     	}
-    	if (osArch.equals("x86_64")) { //$NON-NLS-1$
+    	if (osArch.equals("x86_64") || osArch.equals("amd64")) { //$NON-NLS-1$  //$NON-NLS-2$
     		return MACHINE.AMD64;
     	}
     	if (osArch.equals("x86")) { //$NON-NLS-1$


### PR DESCRIPTION
En algunos sistemas Linux devuelve la cadena "amd64" en lugar de "x86_64" en la variable de entorno "os.arch"

Esto hace que en algunos sistemas no encuentre las librerias nss (en mi caso en Debian).