### PR TITLE
corrige salto de linea de la cabecera

### DIFF
--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/CommandProcessorThread.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/CommandProcessorThread.java
@@ -496,7 +496,7 @@ class CommandProcessorThread extends Thread {
 			sb.append("HTTP/1.1 200 OK\n"); //$NON-NLS-1$
 		}
 		else  {
-			sb.append("HTTP/1.1 500 Internal Server Error"); //$NON-NLS-1$
+			sb.append("HTTP/1.1 500 Internal Server Error\n"); //$NON-NLS-1$
 		}
 		sb.append("Connection: close\n"); //$NON-NLS-1$
 		sb.append("Pragma: no-cache\n"); //$NON-NLS-1$


### PR DESCRIPTION
En el caso de devolver error 500, falta un salto de linea al final de la primera linea, sin el cual se mezclaría con la siguiente línea

Realmente el código actualmente no se ejecuta puesto que todas las llamadas son con ok = true, y por lo tanto siempre devuelve status 200 OK, pero en un futuro podría usarse.