### PR TITLE
Recupera la opción de firmar en XP o Vista (autoscript.js)

### DIFF
--- a/afirma-ui-miniapplet-deploy/src/main/webapp/js/autoscript.js
+++ b/afirma-ui-miniapplet-deploy/src/main/webapp/js/autoscript.js
@@ -638,7 +638,9 @@ var AutoScript = ( function ( window, undefined ) {
 			// Si podemos utilizar un WebSocket local y no estamos en Internet Explorer
 			// (en el que no podemos asegurar el funcionamiento si se encuentra habilitada
 			// una opcion de red concreta), usamos WebSockets 
-			else if (isWebSocketsSupported() && !Platform.isInternetExplorer()) {
+			// Tampoco usamos websockets en XP o Vista puesto que necesitamos autofirma 1.7 
+			// y en esos sistemas el máximo que se puede instalar es la 1.4
+			else if (isWebSocketsSupported() && !Platform.isInternetExplorer() && !Platform.isWindowsVista() && !Platform.isWindowsXP()) {
 				clienteFirma = new AppAfirmaWebSocketClient(window, undefined);
 			}
 			// Si no se esta en una version antigua de Internet Explorer o Safari
@@ -736,6 +738,14 @@ var AutoScript = ( function ( window, undefined ) {
 					navigator.userAgent.toUpperCase().indexOf("CHROMIUM") != -1;
 			}
 			
+			function isWindowsXP() {
+				return navigator.userAgent.indexOf("Windows NT 5") >= 0;
+			}
+			
+			function isWindowsVista() {
+				return navigator.userAgent.indexOf("Windows NT 6.0") >= 0;
+			}
+			
 			/* Metodos que publicamos del objeto */
 			return {
 				isAndroid : isAndroid,
@@ -745,7 +755,9 @@ var AutoScript = ( function ( window, undefined ) {
 				isInternetExplorer7orLower : isInternetExplorer7orLower,
 				isSafari10 : isSafari10,
 				isFirefox : isFirefox,
-				isChrome : isChrome				
+				isChrome : isChrome,
+				isWindowsXP : isWindowsXP,
+				isWindowsVista : isWindowsVista		
 			};
 		})(window, undefined);
 		


### PR DESCRIPTION
### Usar comunicación directa por sockets para Vista y XP

En Vista / XP si usan Chrome o Firefox, el navegador soporta websockets y autoscript actualmente decide usar esa opción. Sin embargo autofirma 1.4 (el máximo que pueden instalar en esos sistemas) no lo soporta y rechaza la firma con un error "SAF_04: Operación no soportada. Compruebe que dispone de la última versión de autofirma"

Con el cambio propuesto usarían la comunicación directa por sockets, el protocolo anterior que si que está soportado por autofirma 1.4. No tenemos que considerar el bloqueo de Chrome o Edge 98+ a este protocolo, puesto que el máximo que se puede instalar en xp y vista es la 49.

No lo he probado, pero debería funcionar.

### Nota sobre soportar sistemas antiguos.

XP lleva 8 años sin soporte y Vista 5 años, pero aún hay un número (reducido) de usuarios que los usan.

Hasta ahora en muchas administraciones se les ha dado soporte manteniendo la versión 1.6 de autoscript. Pero con el problema de compatibilidad surgido con Chrome y Edge 98, se está acelerando la actualización a la versión 1.7. Se deja fuera a la gente de XP y Vista sin darles tiempo a reaccionar, puesto que necesitan comprar un nuevo equipo, en una época en la que hay que hacerlo con tiempo debido a la escasez de componentes y a los altos precios.

El coste de mantener esos sistemas en autoscript actualmente son estas 5 lineas de código, creo que merece la pena darles unos meses más para que se actualicen.
