### PR TITLE
Firmas CAdES con MimeType

### DIFF
--- a/afirma-crypto-cades-multi/src/main/java/es/gob/afirma/signers/multi/cades/AOCAdESCoSigner.java
+++ b/afirma-crypto-cades-multi/src/main/java/es/gob/afirma/signers/multi/cades/AOCAdESCoSigner.java
@@ -14,6 +14,8 @@ import java.security.PrivateKey;
 import java.util.Properties;
 import java.util.logging.Logger;
 
+import org.spongycastle.cms.CMSSignedData;
+
 import es.gob.afirma.core.AOException;
 import es.gob.afirma.core.signers.AOCoSigner;
 import es.gob.afirma.core.signers.AOSignConstants;
@@ -52,7 +54,15 @@ public final class AOCAdESCoSigner implements AOCoSigner {
         // Purgamos e informamos de las compatibilidades de la configuracion establecida
         noticeIncompatibleConfig(algorithm, extraParams);
 
-        final CAdESParameters parameters = CAdESParameters.load(data, algorithm, extraParams);
+        CMSSignedData signedData;
+        try {
+        	signedData = new CMSSignedData(sign);
+        }
+        catch (final Exception e) {
+        	throw new AOException("La firma proporcionada no es CMS/CAdES", e); //$NON-NLS-1$
+		}
+
+        final CAdESParameters parameters = CAdESParameters.load(data, signedData, algorithm, extraParams);
 
 		try {
 			return CAdESCoSigner.coSigner(

--- a/afirma-crypto-cades-multi/src/main/java/es/gob/afirma/signers/multi/cades/CAdESMultiUtil.java
+++ b/afirma-crypto-cades-multi/src/main/java/es/gob/afirma/signers/multi/cades/CAdESMultiUtil.java
@@ -17,9 +17,12 @@ import java.util.List;
 
 import org.spongycastle.asn1.ASN1Encodable;
 import org.spongycastle.asn1.ASN1EncodableVector;
+import org.spongycastle.asn1.ASN1InputStream;
 import org.spongycastle.asn1.ASN1ObjectIdentifier;
 import org.spongycastle.asn1.ASN1Primitive;
+import org.spongycastle.asn1.ASN1Sequence;
 import org.spongycastle.asn1.ASN1Set;
+import org.spongycastle.asn1.ASN1TaggedObject;
 import org.spongycastle.asn1.BERSet;
 import org.spongycastle.asn1.cms.AttributeTable;
 import org.spongycastle.asn1.cms.SignedData;
@@ -124,4 +127,28 @@ public final class CAdESMultiUtil {
     static boolean isCounterSignature(final ASN1ObjectIdentifier oid) {
     	return PKCSObjectIdentifiers.pkcs_9_at_counterSignature.equals(oid);
     }
+
+
+    /**
+     * Carga datos firmados.
+     * @param signature Datos firmados.
+     * @return Estructura de datos firmados.
+     * @throws IOException Cuando falla la carga de la firma
+     */
+	static SignedData readData(final byte[] signature) throws IOException {
+		final ASN1Sequence dsq;
+		try (
+			final ASN1InputStream is = new ASN1InputStream(signature);
+		) {
+			dsq = (ASN1Sequence) is.readObject();
+		}
+		final Enumeration<?> e = dsq.getObjects();
+		// Elementos que contienen los elementos OID SignedData
+		e.nextElement();
+		// Contenido de SignedData
+		final ASN1TaggedObject doj = (ASN1TaggedObject) e.nextElement();
+		final ASN1Sequence contentSignedData = (ASN1Sequence) doj.getObject(); // contenido del SignedData
+
+		return SignedData.getInstance(contentSignedData);
+	}
 }

--- a/afirma-crypto-cades-multi/src/test/java/es/gob/afirma/signers/multi/cades/TestCosignMimeType.java
+++ b/afirma-crypto-cades-multi/src/test/java/es/gob/afirma/signers/multi/cades/TestCosignMimeType.java
@@ -1,0 +1,405 @@
+package es.gob.afirma.signers.multi.cades;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.util.Iterator;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.spongycastle.asn1.ASN1Encodable;
+import org.spongycastle.asn1.ASN1ObjectIdentifier;
+import org.spongycastle.asn1.cms.Attribute;
+import org.spongycastle.asn1.cms.AttributeTable;
+import org.spongycastle.cms.CMSSignedData;
+import org.spongycastle.cms.SignerInformation;
+import org.spongycastle.cms.SignerInformationStore;
+
+import es.gob.afirma.core.misc.AOUtil;
+import es.gob.afirma.core.signers.AOSignConstants;
+import es.gob.afirma.core.signers.AOSigner;
+import es.gob.afirma.core.signers.CounterSignTarget;
+import es.gob.afirma.signers.cades.AOCAdESSigner;
+import es.gob.afirma.signers.cades.CAdESExtraParams;
+
+public class TestCosignMimeType {
+
+	private static final String ATTR_MIMETYPE_OID = "0.4.0.1733.2.1"; //$NON-NLS-1$
+
+	/** MimeType de los datos. */
+	private static final String MIMETYPE_JPEG = "image/jpeg"; //$NON-NLS-1$
+
+
+	private static final String OID_PDF = "1.2.840.10003.5.109.1"; //$NON-NLS-1$
+	private static final String MIMETYPE_PDF = "application/pdf"; //$NON-NLS-1$
+
+	private static final String OID_PNG = "1.2.840.10003.5.109.7"; //$NON-NLS-1$
+	private static final String MIMETYPE_PNG = "image/png"; //$NON-NLS-1$
+	private static final String DESCRIPTION_PNG = "Imagen PNG"; //$NON-NLS-1$
+
+	private static final String DEFAULT_MIMETYPE = "application/octet-stream"; //$NON-NLS-1$
+
+	private static final String FILENAME_JPG = "rubric.jpg"; //$NON-NLS-1$
+	private static final String FILENAME_UNKNOWN = "txt"; //$NON-NLS-1$
+
+	private static final String SIGN_CERT_PATH = "PruebaEmpleado4Activo.p12"; //$NON-NLS-1$
+    private static final String SIGN_CERT_PASS = "Giss2016"; //$NON-NLS-1$
+    private static final String SIGN_CERT_ALIAS = "givenname=prueba4empn+serialnumber=idces-00000000t+sn=p4empape1 p4empape2 - 00000000t+cn=prueba4empn p4empape1 p4empape2 - 00000000t,ou=personales,ou=certificado electronico de empleado publico,o=secretaria de estado de la seguridad social,c=es"; //$NON-NLS-1$
+
+    private static final String CERT_PATH_TO_COSIGN = "00_empleado_publico-hsm.p12"; //$NON-NLS-1$
+    private static final String CERT_PASS_TO_COSIGN = "12345"; //$NON-NLS-1$
+    private static final String CERT_ALIAS_TO_COSIGN = "nombre apellido1 apellido2 - dni 12345678z"; //$NON-NLS-1$
+
+	private byte[] jpegData;
+	private byte[] unknownData;
+
+	private byte[] signatureImplicitWithMimeTypePng;
+	private byte[] signatureImplicitWithoutMimeType;
+	private byte[] signatureExplicitWithoutMimeType;
+	private byte[] signatureExplicitWithContentTypePng;
+	private byte[] signatureExplicitWithContentTypeAndMimeTypePng;
+	private byte[] signatureImplicitWithoutMimeTypeUnknownData;
+
+	private String signatureSignerSid;
+
+	private PrivateKeyEntry signPke;
+	private PrivateKeyEntry cosignPke;
+
+	@Before
+	public void loadData() throws IOException {
+		this.jpegData = loadFileData(FILENAME_JPG);
+		this.unknownData = loadFileData(FILENAME_UNKNOWN);
+	}
+
+	private static byte[] loadFileData(final String filename) throws IOException {
+
+		byte[] data;
+		try (InputStream is = ClassLoader.getSystemResourceAsStream(filename)) {
+			data = AOUtil.getDataFromInputStream(is);
+		}
+		return data;
+	}
+
+	@Before
+	public void loadPrivateKeyEntries() throws Exception {
+
+		KeyStore ks = KeyStore.getInstance("PKCS12"); //$NON-NLS-1$
+		try (
+			final InputStream is = ClassLoader.getSystemResourceAsStream(SIGN_CERT_PATH)
+		) {
+			ks.load(is, SIGN_CERT_PASS.toCharArray());
+		}
+		this.signPke = (PrivateKeyEntry) ks.getEntry(SIGN_CERT_ALIAS, new KeyStore.PasswordProtection(SIGN_CERT_PASS.toCharArray()));
+
+		ks = KeyStore.getInstance("PKCS12"); //$NON-NLS-1$
+		try (
+			final InputStream is = ClassLoader.getSystemResourceAsStream(CERT_PATH_TO_COSIGN)
+		) {
+			ks.load(is, CERT_PASS_TO_COSIGN.toCharArray());
+		}
+		this.cosignPke = (PrivateKeyEntry) ks.getEntry(CERT_ALIAS_TO_COSIGN, new KeyStore.PasswordProtection(CERT_PASS_TO_COSIGN.toCharArray()));
+	}
+
+	@Before
+	public void generateSignatures() throws Exception {
+
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.MODE, AOSignConstants.SIGN_MODE_IMPLICIT);
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_MIME_TYPE, MIMETYPE_PNG);
+		this.signatureImplicitWithMimeTypePng = sign(this.jpegData, extraParams);
+
+		// Identificamos el ID del firmante que se usara en todas las firmas
+		final CMSSignedData s = new CMSSignedData(this.signatureImplicitWithMimeTypePng);
+		final SignerInformationStore signersInfo = s.getSignerInfos();
+		final SignerInformation signerInfo = signersInfo.iterator().next();
+		this.signatureSignerSid = signerInfo.getSID().getSerialNumber().toString();
+
+		extraParams.clear();
+		extraParams.setProperty(CAdESExtraParams.MODE, AOSignConstants.SIGN_MODE_IMPLICIT);
+		this.signatureImplicitWithoutMimeType = sign(this.jpegData, extraParams);
+
+		extraParams.clear();
+		extraParams.setProperty(CAdESExtraParams.MODE, AOSignConstants.SIGN_MODE_EXPLICIT);
+		this.signatureExplicitWithoutMimeType = sign(this.jpegData, extraParams);
+
+		extraParams.clear();
+		extraParams.setProperty(CAdESExtraParams.MODE, AOSignConstants.SIGN_MODE_EXPLICIT);
+		extraParams.setProperty(CAdESExtraParams.CONTENT_TYPE_OID, OID_PNG);
+		extraParams.setProperty(CAdESExtraParams.CONTENT_DESCRIPTION, DESCRIPTION_PNG);
+		this.signatureExplicitWithContentTypePng = sign(this.jpegData, extraParams);
+
+		extraParams.clear();
+		extraParams.setProperty(CAdESExtraParams.MODE, AOSignConstants.SIGN_MODE_EXPLICIT);
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_MIME_TYPE, MIMETYPE_PNG);
+		extraParams.setProperty(CAdESExtraParams.CONTENT_TYPE_OID, OID_PNG);
+		extraParams.setProperty(CAdESExtraParams.CONTENT_DESCRIPTION, DESCRIPTION_PNG);
+		this.signatureExplicitWithContentTypeAndMimeTypePng = sign(this.jpegData, extraParams);
+
+		extraParams.clear();
+		extraParams.setProperty(CAdESExtraParams.MODE, AOSignConstants.SIGN_MODE_IMPLICIT);
+		this.signatureImplicitWithoutMimeTypeUnknownData = sign(this.unknownData, extraParams);
+	}
+
+	/**
+	 * Comprueba que una firma CAdES sin configuraci&oacute;n relacionada con
+	 * el mimetype de los datos no incluye su MimeType.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesPorDefecto() throws Exception {
+
+		final Properties extraParams = new Properties();
+		final byte[] cosignature = cosign(this.signatureImplicitWithMimeTypePng, extraParams);
+		final String mimeType = getMimeType(cosignature);
+
+		Assert.assertNull("No se debe agregar el mimetype a las cofirmas CAdES por defecto", mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una cofirma CAdES en la que se indica que se incluya el
+	 * MimeType y se indica uno, incluye ese MimeType.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeIndicandolo() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_MIME_TYPE, MIMETYPE_PDF);
+		final byte[] signature = cosign(this.signatureImplicitWithMimeTypePng, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType indicado", MIMETYPE_PDF, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una cofirma CAdES en la que se indica que se incluya el
+	 * MimeType y no se indica uno, pero si se indica el OID de los datos,
+	 * incluye el MimeType correspondiente al OID.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeIndicandoOid() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_TYPE_OID, OID_PDF);
+		final byte[] signature = cosign(this.signatureImplicitWithMimeTypePng, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType del OID indicado", MIMETYPE_PDF, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una cofirma CAdES en la que se indica que se incluya el
+	 * MimeType, pero no se indica ni el MimeType ni el OID de los datos,
+	 * incluye el MimeType de la firma original.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicarYFirmaConEl() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = cosign(this.signatureImplicitWithMimeTypePng, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType de los datos", MIMETYPE_PNG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una cofirma CAdES en la que se indica que se incluya el
+	 * MimeType, pero no se indica ni el MimeType ni el OID de los datos,
+	 * y en el que la firma original tenida un OID,  incluye el MimeType
+	 * correspondiente al OID de de la firma.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicarYFirmaConOid() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = cosign(this.signatureExplicitWithContentTypePng, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType de los datos", MIMETYPE_PNG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una cofirma CAdES en la que se indica que se incluya el
+	 * MimeType, pero no se indica ni el MimeType ni el OID de los datos,
+	 * incluye el MimeType y el OID de la firma original.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicarYFirmaConMimeTypeyOid() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = cosign(this.signatureExplicitWithContentTypeAndMimeTypePng, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType de los datos", MIMETYPE_PNG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una cofirma CAdES en la que se indica que se incluya el
+	 * MimeType y no se indica ni el MimeType ni el OID de los datos ni se
+	 * puede determinar el tipo a trav&eacute;s de los propios datos,
+	 * incluye el MimeType gen&eeacute;rico.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicarYFirmaImplicitaSinTipo() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = cosign(this.signatureImplicitWithoutMimeType, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType por defecto", MIMETYPE_JPEG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que se incluya el
+	 * MimeType y no se indica ni el MimeType ni el OID de los datos, ni se
+	 * encuentra informaci&oacute;n en la firma previa, ni contiene esta los
+	 * datos firmados, incluye el MimeType gen&eeacute;rico.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicarYFirmaDatosDesconocidosSinTipo() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = cosign(this.signatureExplicitWithoutMimeType, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType por defecto", MIMETYPE_JPEG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que se incluya el
+	 * MimeType y no se indica ni el MimeType ni el OID de los datos, cuando
+	 * la no incluye los datos ni el mimetype, incluye incluye el MimeType
+	 * correspondiente al OID del Content Type.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicarYFirmaSinDatosNiMimeType() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = cosign(this.signatureExplicitWithoutMimeType, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType por defecto", MIMETYPE_JPEG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que se incluya el
+	 * MimeType y no se indica ni el MimeType ni el OID de los datos ni se
+	 * puede determinar el tipo a trav&eacute;s de los propios datos,
+	 * incluye el MimeType gen&eeacute;rico.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void contrafirmaConMimeType() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_MIME_TYPE, MIMETYPE_JPEG);
+		final byte[] signature = countersign(this.signatureImplicitWithMimeTypePng, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertNull("Se ha agregado un MimeType a la contrafirma", mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Genera una firma CAdES de los datos con la configuraci&oacute;n de firma indicada.
+	 * @param data Datos a firmar.
+	 * @param extraParams Configuraci&oacute;n de firma.
+	 * @return Firma CAdES.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	private byte[] sign(final byte[] data, final Properties extraParams) throws Exception {
+
+		final AOSigner signer = new AOCAdESSigner();
+		final byte[] signature = signer.sign(
+				data,
+				"SHA512withRSA", //$NON-NLS-1$
+				this.signPke.getPrivateKey(),
+				this.signPke.getCertificateChain(),
+				extraParams);
+
+		return signature;
+	}
+
+	/**
+	 * Genera una cofirma CAdES con la configuraci&oacute;n de firma indicada.
+	 * @param signature Firma a cofirmar.
+	 * @param extraParams Configuraci&oacute;n para la cofirma.
+	 * @return Cofirma CAdES.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	private byte[] cosign(final byte[] signature, final Properties extraParams) throws Exception {
+
+		final AOSigner signer = new AOCAdESSigner();
+		final byte[] cosignature = signer.cosign(
+				signature,
+				"SHA512withRSA", //$NON-NLS-1$
+				this.cosignPke.getPrivateKey(),
+				this.cosignPke.getCertificateChain(),
+				extraParams);
+
+		return cosignature;
+	}
+
+	/**
+	 * Genera una cofirma CAdES con la configuraci&oacute;n de firma indicada.
+	 * @param signature Firma a cofirmar.
+	 * @param extraParams Configuraci&oacute;n para la cofirma.
+	 * @return Cofirma CAdES.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	private byte[] countersign(final byte[] signature, final Properties extraParams) throws Exception {
+
+		final AOSigner signer = new AOCAdESSigner();
+		final byte[] cosignature = signer.countersign(
+				signature,
+				"SHA512withRSA", //$NON-NLS-1$
+				CounterSignTarget.LEAFS,
+				null,
+				this.cosignPke.getPrivateKey(),
+				this.cosignPke.getCertificateChain(),
+				extraParams);
+
+		return cosignature;
+	}
+
+	/**
+	 * Extrae el atributo firmado id_aa_ets_mimeType de una cofirma CAdES
+	 * asegurandose de no extraer el de la firma original.
+	 * @param signature Cofirma CAdES.
+	 * @return Valor del atributo firmado o {@code null} si no se encuentra.
+	 * @throws Exception Cuando la firma no es CMS/CAdES o no esta bien formada.
+	 */
+	private String getMimeType(final byte[] signature) throws Exception {
+
+		final CMSSignedData s = new CMSSignedData(signature);
+		final SignerInformationStore signersInfo = s.getSignerInfos();
+		final Iterator<SignerInformation> signersIt = signersInfo.iterator();
+
+		while (signersIt.hasNext()) {
+			final SignerInformation signerInfo = signersIt.next();
+			if (!signerInfo.getSID().getSerialNumber().toString().equals(this.signatureSignerSid)) {
+				final AttributeTable signedAttributes = signerInfo.getSignedAttributes();
+				final Attribute mimetypeAttr = signedAttributes.get(new ASN1ObjectIdentifier(ATTR_MIMETYPE_OID));
+				if (mimetypeAttr == null) {
+					return null;
+				}
+				final ASN1Encodable asn1Value = mimetypeAttr.getAttributeValues()[0];
+				return asn1Value.toString();
+			}
+		}
+		return null;
+	}
+
+}
+

--- a/afirma-crypto-cades/src/main/java/es/gob/afirma/signers/cades/CAdESAttributes.java
+++ b/afirma-crypto-cades/src/main/java/es/gob/afirma/signers/cades/CAdESAttributes.java
@@ -1,0 +1,16 @@
+package es.gob.afirma.signers.cades;
+
+public class CAdESAttributes {
+
+	/**
+	 * Identificador del id-aa-ets-signerAttrV2. Esta propiedad se utiliza para indicar
+	 * los roles en las firmas baseline ETSI EN 319 122-1.
+	 */
+	public static final String OID_id_aa_ets_signerAttrV2 =  "0.4.0.19122.1.1"; //$NON-NLS-1$
+
+    /**
+	 * Identificador del id-aa-ets-mimeType. Esta propiedad se utiliza para incluir el MimeType
+	 * de los datos en la firma. Definido por primera vez en ETSI TS 101 733 V2.1.1 (2012-03).
+	 */
+    public static final String OID_id_aa_ets_mimeType =  "0.4.0.1733.2.1"; //$NON-NLS-1$
+}

--- a/afirma-crypto-cades/src/main/java/es/gob/afirma/signers/cades/CAdESExtraParams.java
+++ b/afirma-crypto-cades/src/main/java/es/gob/afirma/signers/cades/CAdESExtraParams.java
@@ -85,6 +85,24 @@ public final class CAdESExtraParams {
     public static final String CONTENT_TYPE_OID = "contentTypeOid"; //$NON-NLS-1$
 
     /**
+     *  Si se indica <code>true</code>, se incluir&aacute; el atributo <i>mime-type</i>
+     *  (OID:0.4.0.1733.2.1) seg&uacute;n las reglas definidas en la IETF RFC 2045. El
+     *  valor del mimetype se tomar&acute; de la propiedad {@code #CONTENT_MIME_TYPE}.
+     *  Si esta no se definiese, se identificar&aacute; el mimetype correspondiente al
+     *  OID establecido en la propiedad {@code #CONTENT_TYPE_OID}. Si esta tampoco se
+     *  definiese, se usar&aacute; el mimetype identificado a ra&iacute;z del
+     *  an&aacute;lisis de los datos firmados o el gen&eacute;rico si no se identificase.
+     *  En el caso de cofirmas, se copiar&acute; el mimetype de la firma original si lo
+     *  tuviese. Si no, se seguir&iacute;a con la cadena de comprobaciones ya indicada.
+     *  En las contrafirmas no se incluir&aacute; este atributo.
+     */
+    public static final String INCLUDE_MIMETYPE_ATTRIBUTE = "includeMimeTypeAttribute"; //$NON-NLS-1$
+
+    /** MIME-Type de los datos a firmar. Se utilizar&aacute; s&oacute;lo cuando tambi&eacute;se
+     * utilice la propiedad {@code #INCLUDE_MIMETYPE_ATTRIBUTE}. */
+    public static final String CONTENT_MIME_TYPE = "mimeType"; //$NON-NLS-1$
+
+    /**
      *  Identificador de la pol&iacute;tica de firma. Debe ser un OID (o una URN de tipo OID) que identifique
      *  &uacute;nivocamente la pol&iacute;tica en formato ASN.1 procesable.
      *  <br> Propiedad compartida con XAdES y PAdES)

--- a/afirma-crypto-cades/src/main/java/es/gob/afirma/signers/cades/CAdESUtils.java
+++ b/afirma-crypto-cades/src/main/java/es/gob/afirma/signers/cades/CAdESUtils.java
@@ -163,12 +163,6 @@ import es.gob.afirma.signers.pkcs7.SigUtils;
  *  */
 public final class CAdESUtils {
 
-	/**
-	 * Identificador del id-aa-ets-signerAttrV2. Esta propiedad se utiliza para indicar
-	 * los roles en las firmas baseline ETSI EN 319 122-1.
-	 */
-    private static final String OID_id_aa_ets_signerAttrV2 =  "0.4.0.19122.1.1"; //$NON-NLS-1$
-
 	private CAdESUtils() {
         // No permitimos la instanciacion
     }
@@ -535,7 +529,7 @@ public final class CAdESUtils {
         			signerAttrOid = PKCSObjectIdentifiers.id_aa_ets_signerAttr;
         		}
         		else if (AOSignConstants.SIGN_PROFILE_BASELINE.equals(config.getProfileSet()) ) {
-        			signerAttrOid = new ASN1ObjectIdentifier(OID_id_aa_ets_signerAttrV2);
+        			signerAttrOid = new ASN1ObjectIdentifier(CAdESAttributes.OID_id_aa_ets_signerAttrV2);
         		}
         		// Agregamos los roles
         		if (signerAttrOid != null) {
@@ -564,6 +558,16 @@ public final class CAdESUtils {
 						new DERUTCTime(config.getSigningTime())
 					)
 				)
+			);
+        }
+
+        // El mimetype de los datos firmados. Solo se agrega si se indica expresamente y nunca
+        // en las contrafirmas
+        if (!isCountersign && config.getMimeType() != null) {
+        	contextSpecific.add(
+        			new Attribute(
+        					new ASN1ObjectIdentifier(CAdESAttributes.OID_id_aa_ets_mimeType),
+        					new DERSet(new DERUTF8String(config.getMimeType())))
 			);
         }
 

--- a/afirma-crypto-cades/src/test/java/es/gob/afirma/test/cades/TestCAdESMimeType.java
+++ b/afirma-crypto-cades/src/test/java/es/gob/afirma/test/cades/TestCAdESMimeType.java
@@ -1,0 +1,251 @@
+package es.gob.afirma.test.cades;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.spongycastle.asn1.ASN1Encodable;
+import org.spongycastle.asn1.ASN1ObjectIdentifier;
+import org.spongycastle.asn1.cms.Attribute;
+import org.spongycastle.asn1.cms.AttributeTable;
+import org.spongycastle.cms.CMSSignedData;
+import org.spongycastle.cms.SignerInformation;
+import org.spongycastle.cms.SignerInformationStore;
+
+import es.gob.afirma.core.misc.AOUtil;
+import es.gob.afirma.core.signers.AOSigner;
+import es.gob.afirma.signers.cades.AOCAdESSigner;
+import es.gob.afirma.signers.cades.CAdESExtraParams;
+
+public class TestCAdESMimeType {
+
+	private static final String ATTR_MIMETYPE_OID = "0.4.0.1733.2.1"; //$NON-NLS-1$
+
+	/** MimeType de los datos. */
+	private static final String MIMETYPE_JPEG = "image/jpeg"; //$NON-NLS-1$
+
+	/** OID correspondiente a datos JPEG. */
+	private static final String OID_PDF = "1.2.840.10003.5.109.1"; //$NON-NLS-1$
+	private static final String MIMETYPE_PDF = "application/pdf"; //$NON-NLS-1$
+
+	private static final String DEFAULT_MIMETYPE = "application/octet-stream"; //$NON-NLS-1$
+
+	private static final String FILENAME_JPG = "rubric.jpg"; //$NON-NLS-1$
+	private static final String FILENAME_UNKNOWN = "txt"; //$NON-NLS-1$
+
+	private static final String CERT_PATH = "PruebaEmpleado4Activo.p12"; //$NON-NLS-1$
+    private static final String CERT_PASS = "Giss2016"; //$NON-NLS-1$
+    private static final String CERT_ALIAS = "givenname=prueba4empn+serialnumber=idces-00000000t+sn=p4empape1 p4empape2 - 00000000t+cn=prueba4empn p4empape1 p4empape2 - 00000000t,ou=personales,ou=certificado electronico de empleado publico,o=secretaria de estado de la seguridad social,c=es"; //$NON-NLS-1$
+
+//	private static final String CERT_PATH = "EIDAS_CERTIFICADO_PRUEBAS___99999999R.p12"; //$NON-NLS-1$
+//    private static final String CERT_PASS = "1234"; //$NON-NLS-1$
+//    private static final String CERT_ALIAS = "eidas_certificado_pruebas___99999999r"; //$NON-NLS-1$
+
+	private byte[] jpegData;
+
+	private byte[] unknownData;
+
+	private PrivateKeyEntry pke;
+
+	@Before
+	public void loadData() throws IOException {
+		this.jpegData = loadFileData(FILENAME_JPG);
+		this.unknownData = loadFileData(FILENAME_UNKNOWN);
+	}
+
+	private static byte[] loadFileData(final String filename) throws IOException {
+
+		byte[] data;
+		try (InputStream is = ClassLoader.getSystemResourceAsStream(filename)) {
+			data = AOUtil.getDataFromInputStream(is);
+		}
+		return data;
+	}
+
+	@Before
+	public void loadPrivateKeyEntry() throws Exception {
+
+		final KeyStore ks = KeyStore.getInstance("PKCS12"); //$NON-NLS-1$
+		try (
+			final InputStream is = ClassLoader.getSystemResourceAsStream(CERT_PATH)
+		) {
+			ks.load(is, CERT_PASS.toCharArray());
+		}
+		this.pke = (PrivateKeyEntry) ks.getEntry(CERT_ALIAS, new KeyStore.PasswordProtection(CERT_PASS.toCharArray()));
+	}
+
+	/**
+	 * Comprueba que una firma CAdES sin configuraci&oacute;n relacionada con
+	 * el mimetype de los datos no incluye su MimeType.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesPorDefecto() throws Exception {
+
+		final Properties extraParams = new Properties();
+		final byte[] signature = sign(this.jpegData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertNull("No se debe agregar el mimetype a las firmas CAdES por defecto", mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que no se indica que se incluya el
+	 * mimetype, pero en el que s&iacute; se declara, no incluye el MimeType.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesPorDefectoIndicandoMimeType() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.CONTENT_MIME_TYPE, MIMETYPE_JPEG);
+		final byte[] signature = sign(this.jpegData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertNull("No se debe agregar el mimetype a las firmas CAdES que no pidan incluirlo", mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que no se incluya el
+	 * MimeType y no se indica, no incluye el MimeType.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesSinMimetype() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.FALSE.toString());
+		final byte[] signature = sign(this.jpegData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertNull("No se debe agregar el mimetype a las firmas CAdES que no pidan incluirlo", mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que no se incluya el
+	 * MimeType pero s&iacute; se indica uno, no incluye el MimeType.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesSinMimeTypeIndicandolo() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.FALSE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_MIME_TYPE, MIMETYPE_JPEG);
+		final byte[] signature = sign(this.jpegData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertNull("No se debe agregar el mimetype a las firmas CAdES que no pidan incluirlo", mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que se incluya el
+	 * MimeType y se indica uno, incluye ese MimeType.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeIndicandolo() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_MIME_TYPE, MIMETYPE_JPEG);
+		final byte[] signature = sign(this.jpegData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType indicado", MIMETYPE_JPEG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que se incluya el
+	 * MimeType y no se indica uno, pero si se indica el OID de los datos,
+	 * incluye el MimeType correspondiente al OID.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeIndicandoOid() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		extraParams.setProperty(CAdESExtraParams.CONTENT_TYPE_OID, OID_PDF);
+		final byte[] signature = sign(this.jpegData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType del OID indicado", MIMETYPE_PDF, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que se incluya el
+	 * MimeType, pero no se indica ni el MimeType ni el OID de los datos,
+	 * incluye el MimeType correspondiente al an&aacute;lisis de los datos.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicar() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = sign(this.jpegData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType de los datos", MIMETYPE_JPEG, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Comprueba que una firma CAdES en la que se indica que se incluya el
+	 * MimeType y no se indica ni el MimeType ni el OID de los datos ni se
+	 * puede determinar el tipo a trav&eacute;s de los propios datos,
+	 * incluye el MimeType gen&eeacute;rico.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	@Test
+	public void cadesConMimeTypeSinIndicarYDatosNoReconocidos() throws Exception {
+		final Properties extraParams = new Properties();
+		extraParams.setProperty(CAdESExtraParams.INCLUDE_MIMETYPE_ATTRIBUTE, Boolean.TRUE.toString());
+		final byte[] signature = sign(this.unknownData, extraParams);
+		final String mimeType = getMimeType(signature);
+
+		Assert.assertEquals("No se ha agregado el MimeType por defecto", DEFAULT_MIMETYPE, mimeType); //$NON-NLS-1$
+	}
+
+	/**
+	 * Genera una firma CAdES de los datos con la configuraci&oacute;n de firma indicada.
+	 * @param data Datos a firmar.
+	 * @param extraParams Configuraci&oacute;n de firma.
+	 * @return Firma CAdES.
+	 * @throws Exception Cuando ocurre un error en la firma.
+	 */
+	private byte[] sign(final byte[] data, final Properties extraParams) throws Exception {
+
+		final AOSigner signer = new AOCAdESSigner();
+		final byte[] signature = signer.sign(
+				data,
+				"SHA512withRSA", //$NON-NLS-1$
+				this.pke.getPrivateKey(),
+				this.pke.getCertificateChain(),
+				extraParams);
+
+		return signature;
+	}
+
+	/**
+	 * Extrae el atributo firmado id_aa_ets_mimeType de una firma CAdES.
+	 * @param signature Firma CAdES.
+	 * @return Valor del atributo firmado o {@code null} si no se encuentra.
+	 * @throws Exception Cuando la firma no es CMS/CAdES o no esta bien formada.
+	 */
+	private static String getMimeType(final byte[] signature) throws Exception {
+
+		final CMSSignedData s = new CMSSignedData(signature);
+		final SignerInformationStore signersInfo = s.getSignerInfos();
+		final SignerInformation signerInfo = signersInfo.iterator().next();
+
+		final AttributeTable signedAttributes = signerInfo.getSignedAttributes();
+		final Attribute mimetypeAttr = signedAttributes.get(new ASN1ObjectIdentifier(ATTR_MIMETYPE_OID));
+		if (mimetypeAttr == null) {
+			return null;
+		}
+
+		final ASN1Encodable asn1Value = mimetypeAttr.getAttributeValues()[0];
+
+		return asn1Value.toString();
+	}
+}

--- a/afirma-server-triphase-signer/src/main/resources/tps_config.properties
+++ b/afirma-server-triphase-signer/src/main/resources/tps_config.properties
@@ -50,10 +50,10 @@ document.cache.manager=es.gob.afirma.triphase.server.cache.FileSystemCacheManage
 # Existe una vulnerabilidad en el formato PDF que puede hacer que al crear una
 # nueva revision de un documento firmado con PAdES se modifique su apariencia
 # sin invalidar sus firmas. Esto no afecta a la validez del documento ya que es
-# posible comprobar el contenido firmado correctamente, pero un usuario que no
-# lo compruebe expresamente podría creer a simple vista que se firmo algo
+# posible comprobar correctamente el contenido que se firmo, pero un usuario que
+# no lo compruebe expresamente podria creer a simple vista que se firmo algo
 # distinto a lo que realmente se firmo. Este tipo de ataques se conocen como
-# PDF Shadow Attack y su comprobación es computacionalmente costosa ya que debe
+# PDF Shadow Attack y su comprobacion es computacionalmente costosa ya que debe
 # revisarse pagina a pagina. Para limitar la carga en el servidor se permite
 # restringir el numero maximo de paginas sobre las que se realizara la
 # comprobacion. La comprobacion solo se realizar cuando lo solicite la

--- a/afirma-simple/src/main/resources/help/Spanish.lproj/pgs/LineaComandos.html
+++ b/afirma-simple/src/main/resources/help/Spanish.lproj/pgs/LineaComandos.html
@@ -100,8 +100,8 @@ Opciones:
   <ul>
   <li style="margin-top: 15pt"><code>mode</code>:</li>
   	<ul>
-  	<li><code>explicit</code>:	La firma resultante no incluir&aacute; los datos firmados. Si no se indica el par&aacute;metro mode se configura autom&aacute;ticamente este comportamiento.</li>
-  	<li><code>implicit</code>:	La firma resultante no incluir&aacute; los datos firmados. La firma resultante incluir&aacute; internamente una copia de los datos firmados. El uso de este valor podr&iacute;a generar firmas de gran tama&ntilde;o. En las cofirmas, este par&aacute;metro se ignorar&aacute; si los datos ya estaban contenidos en la firma original o si no se proporcionan los datos.</li>
+  	<li><code>explicit</code>:	La firma resultante no incluir&aacute; los datos firmados. Si no se indica el la propiedad <code>mode</code> se configura autom&aacute;ticamente este comportamiento.</li>
+  	<li><code>implicit</code>:	La firma resultante no incluir&aacute; los datos firmados. La firma resultante incluir&aacute; internamente una copia de los datos firmados. El uso de este valor podr&iacute;a generar firmas de gran tama&ntilde;o. En las cofirmas, esta propiedad se ignorar&aacute; si los datos ya estaban contenidos en la firma original o si no se proporcionan los datos.</li>
 	</ul>
   <li style="margin-top: 10pt"><code>contentTypeOid</code>:</li>
   <ul>
@@ -111,24 +111,33 @@ Opciones:
   <ul>
   	<li>Descripci&oacute;n textual del tipo de datos firmado.</li>
   </ul>
+  <li style="margin-top: 10pt"><code>includeMimeTypeAttribute</code>:</li>
+  <ul>
+ 	<li><code>true</code>:	Incluye en la firma el atributo id-aa-ets-mimeType definido en CAdES v2.1.1 y superiores (v&aacute;lido en firmas baseline). El valor de mimetype se tomar&aacute; de la propiedad <code>mimetype</code> o, si no se incluyo, se extrapolar&aacute; de la propiedad <code>contentTypeOid</code>. Si tampoco fuese posible, se tratar&aacute;n de obtener estos valores de alguna de las firmas previas (en caso de cofirmas). Si tampoco fuese posible, se obtendr&aacute; el tipo del an&aacute;lisis de los datos (que podr&iacute;a no ser correcto o concreto). En caso de que no se pueda obtener el tipo de ninguna manera, se usar&aacute; el mimetype application/octet-stream.</li>
+ 	<li><code>false</code>:	No incluye el atributo id-aa-ets-mimeType en la firma. Valor por defecto.</li>
+  </ul>
+  <li style="margin-top: 10pt"><code>mimeType</code>:</li>
+  <ul>
+  	<li>MIME-Type de los datos a firmar. Sólo se incluye cuando se indica la propiedad <code>includeMimeTypeAttribute</code>.</li>
+  </ul>
   <li style="margin-top: 10pt"><code>policyIdentifier</code>:</li>
   <ul>
   	<li>Identificador de la pol&iacute;tica de firma, necesario para generar firmas CAdES-EPES.</li>
   </ul>
   <li style="margin-top: 10pt"><code>policyIdentifierHash</code>:</li>
   <ul>
-  	<li>Cadena Base 64 con la huella digital de la pol&iacute;tica de firma. Es obligatorio indicar este par&aacute;metro si de indic&oacute; tambi&eacute;n policyIdentifier, al igual que es obligatorio tambi&eacute;n dar valor al par&aacute;metro policyIdentifierHashAlgorithm.</li>
+  	<li>Cadena Base 64 con la huella digital de la pol&iacute;tica de firma. Es obligatorio indicar este par&aacute;esta propiedad si de indic&oacute; tambi&eacute;n policyIdentifier, al igual que es obligatorio tambi&eacute;n dar valor al a la propiedad <code>policyIdentifierHashAlgorithm</code>.</li>
   </ul>	
   <li style="margin-top: 10pt"><code>policyIdentifierHashAlgorithm</code>:</li>
   	<ul>
-  	<li><code>SHA1</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA1.</li>
-  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-256.</li>
-  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-384.</li>
-  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-512.</li>
+  	<li><code>SHA1</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA1.</li>
+  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-256.</li>
+  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-384.</li>
+  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-512.</li>
 	</ul>
   <li style="margin-top: 10pt"><code>policyQualifier</code>:</li>
   <ul>
-  	<li>URL accesible hacia el documento (normalmente PDF) que contiene una descripci&oacute;n textual de la pol&iacute;tica de firma. Este par&aacute;metro es opcional incluso si se desea generar firmas CAdES-EPES.</li>
+  	<li>URL accesible hacia el documento (normalmente PDF) que contiene una descripci&oacute;n textual de la pol&iacute;tica de firma. Esta propiedad es opcional incluso si se desea generar firmas CAdES-EPES.</li>
   </ul>
   <li style="margin-top: 10pt"><code>includeOnlySignningCertificate</code>:</li>
   	<ul>
@@ -137,7 +146,7 @@ Opciones:
 	</ul>
   <li style="margin-top: 10pt"><code>policyQualifier</code>:</li>
   <ul>
-  	<li>URL accesible hacia el documento (normalmente PDF) que contiene una descripci&oacute;n textual de la pol&iacute;tica de firma. Este par&aacute;metro es opcional incluso si se desea generar firmas CAdES-EPES.</li>
+  	<li>URL accesible hacia el documento (normalmente PDF) que contiene una descripci&oacute;n textual de la pol&iacute;tica de firma. Esta propiedad es opcional incluso si se desea generar firmas CAdES-EPES.</li>
   </ul>
   <li style="margin-top: 10pt"><code>signatureProductionCity</code>:</li>
   <ul>
@@ -186,7 +195,7 @@ Opciones:
   <ul>
   <li style="margin-top: 10pt"><code>insertEnvelopedSignatureOnNodeByXPath</code>:</li>
   <ul>
-  	<li>Expresi&oacute;n XPath (v1) que indica el nodo bajo el cual debe insertarse el nodo de firma en el caso de una firma Enveloped. Si la expresi&oacute;n devuelve m&aacute;s de un nodo, se usa solo el primero. Si la expresi&oacute;n no devuelve nodos o est&aacute; mal construida se lanzar&aacute; una excepci&oacute;n. Este par&aacute;metro solo tiene efecto en firmas Enveloped.</li>
+  	<li>Expresi&oacute;n XPath (v1) que indica el nodo bajo el cual debe insertarse el nodo de firma en el caso de una firma Enveloped. Si la expresi&oacute;n devuelve m&aacute;s de un nodo, se usa solo el primero. Si la expresi&oacute;n no devuelve nodos o est&aacute; mal construida se lanzar&aacute; una excepci&oacute;n. Esta propiedad solo tiene efecto en firmas Enveloped.</li>
   </ul>
   <li style="margin-top: 10pt"><code>useManifest</code>:</li>
   	<ul>
@@ -211,15 +220,15 @@ Opciones:
 
   <li style="margin-top: 10pt"><code>mimetype<i><b>n</b></i></code>:</li>
   <ul>
-  	<li>MIME-Type de los datos asociados a la referencia ‘n’ en una firma manifest. Si no se indica este par&aacute;metro, se utilizar&aacute; el tipo ‘application/octet-stream’.</li>
+  	<li>MIME-Type de los datos asociados a la referencia ‘n’ en una firma manifest. Si no se indica esta propiedad, se utilizar&aacute; el tipo ‘application/octet-stream’.</li>
   </ul>
   <li style="margin-top: 10pt"><code>contentTypeOid<i><b>n</b></i></code>:</li>
   <ul>
-  	<li>OID o URN del tipo de dato firmado para la referencia n&uacute;mero ‘n’ en una firma manifest. Este par&aacute;metro es complementario (que no excluyente) al par&aacute;metro <code>mimetype<i><b>n</b></i></code>.</li>
+  	<li>OID o URN del tipo de dato firmado para la referencia n&uacute;mero ‘n’ en una firma manifest. Esta propiedad es complementaria (que no excluyente) a la propiedad <code>mimetype<i><b>n</b></i></code>.</li>
   </ul>
   <li style="margin-top: 10pt"><code>encoding<i><b>n</b></i></code>:</li>
   <ul>
-  	<li>Codificaci&oacute;n de los datos asociados a la referencia n&uacute;mero ‘n’ en una firma manifest. Un uso incorrecto de este par&aacute;metro puede provocar la generaci&oacute;n de una firma inv&aacute;lida.</li>
+  	<li>Codificaci&oacute;n de los datos asociados a la referencia n&uacute;mero ‘n’ en una firma manifest. Un uso incorrecto de esta propiedad puede provocar la generaci&oacute;n de una firma inv&aacute;lida.</li>
   </ul>
   <li style="margin-top: 10pt"><code>addKeyInfoKeyValue</code>:</li>
   	<ul>
@@ -233,7 +242,7 @@ Opciones:
 	</ul>
   <li style="margin-top: 10pt"><code>avoidXpathExtraTransformsOnEnveloped</code>:</li>
   	<ul>
-  	<li><code>true</code>: Evita la inclusi&oacute;n de la transformaci&oacute;n XPATH2 que normalmente se a&ntilde;ade para posibilitar las cofirmas y que elimina todas las firmas del documento para dejar &uacute;nicamente el contenido. ADVERTENCIA: La cofirma de un documento en el que al menos una de las firmas no incluye la transformaci&oacute;n XPATH, dar&aacute; lugar a un documento de firma que potencialmente ser&aacute; validado incorrectamente por los validadores de firma. Por este motivo, s&oacute;lo se permite el uso de este par&aacute;metro en la operaci&oacute;n de firma (no en la de cofirma).</li>
+  	<li><code>true</code>: Evita la inclusi&oacute;n de la transformaci&oacute;n XPATH2 que normalmente se a&ntilde;ade para posibilitar las cofirmas y que elimina todas las firmas del documento para dejar &uacute;nicamente el contenido. ADVERTENCIA: La cofirma de un documento en el que al menos una de las firmas no incluye la transformaci&oacute;n XPATH, dar&aacute; lugar a un documento de firma que potencialmente ser&aacute; validado incorrectamente por los validadores de firma. Por este motivo, s&oacute;lo se permite el uso de esta propiedad en la operaci&oacute;n de firma (no en la de cofirma).</li>
   	<li><code>false</code>: Incluye la transformaci&oacute;n XPATH2 posibilita las cofirmas eliminando todas las firmas del documento para dejar &uacute;nicamente el contenido (comportamiento por defecto).</li>
 	</ul>
   <li style="margin-top: 10pt"><code>format</code>:</li>
@@ -254,22 +263,22 @@ Opciones:
   </ul>
   <li style="margin-top: 10pt"><code>policyIdentifierHash</code>:</li>
   <ul>
-  	<li>Cadena Base 64 con la huella digital de la pol&iacute;tica de firma. Es obligatorio indicar este par&aacute;metro si de indic&oacute; tambi&eacute;n policyIdentifier, al igual que es obligatorio tambi&eacute;n dar valor al par&aacute;metro policyIdentifierHashAlgorithm.</li>
+  	<li>Cadena Base 64 con la huella digital de la pol&iacute;tica de firma. Es obligatorio indicar esta propiedad si de indic&oacute; tambi&eacute;n policyIdentifier, al igual que es obligatorio tambi&eacute;n dar valor a la propiedad <code>policyIdentifierHashAlgorithm</code>.</li>
   </ul>	
   <li style="margin-top: 10pt"><code>policyIdentifierHashAlgorithm</code>:</li>
   	<ul>
-  	<li><code>SHA1</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA1.</li>
-  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-256.</li>
-  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-384.</li>
-  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-512.</li>
+  	<li><code>SHA1</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA1.</li>
+  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-256.</li>
+  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-384.</li>
+  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-512.</li>
 	</ul>
   <li style="margin-top: 10pt"><code>policyQualifier</code>:</li>
   <ul>
-  	<li>URL accesible hacia el documento (normalmente PDF) que contiene una descripci&oacute;n textual de la pol&iacute;tica de firma. Este par&aacute;metro es opcional incluso si se desea generar firmas XAdES-EPES.</li>
+  	<li>URL accesible hacia el documento (normalmente PDF) que contiene una descripci&oacute;n textual de la pol&iacute;tica de firma. Esta propiedad es opcional incluso si se desea generar firmas XAdES-EPES.</li>
   </ul>
   <li style="margin-top: 10pt"><code>policyDescription</code>:</li>
   <ul>
-  	<li>Descripci&oacute;n textual de la pol&iacute;tica de firma. En el caso de que se firme un XML, la codificaci&oacute;n del texto usado debe adecuarse al XML firmado. Este par&aacute;metro es opcional incluso si se desea generar firmas XAdES-EPES.</li>
+  	<li>Descripci&oacute;n textual de la pol&iacute;tica de firma. En el caso de que se firme un XML, la codificaci&oacute;n del texto usado debe adecuarse al XML firmado. Esta propiedad es opcional incluso si se desea generar firmas XAdES-EPES.</li>
   </ul>		
   <li style="margin-top: 10pt"><code>signerClaimedRoles</code>:</li>
   <ul>
@@ -299,11 +308,11 @@ Opciones:
 	</ul>
   <li style="margin-top: 10pt"><code>mimeType</code>:</li>
   <ul>
-  	<li>MIME-Type de los datos a firmar. Si no se indica este par&aacute;metro el sistema intenta auto-detectar el tipo, estableciendo el m&aacute;s aproximado (que puede no ser el estrictamente correcto).</li>
+  	<li>MIME-Type de los datos a firmar. Si no se indica esta propiedad el sistema intenta auto-detectar el tipo, estableciendo el m&aacute;s aproximado (que puede no ser el estrictamente correcto).</li>
   </ul>	
   <li style="margin-top: 10pt"><code>encoding</code>:</li>
   <ul>
-  	<li>URI con la codificaci&oacute;n de los datos a firmar (ver la  documentaci&oacute;n del elemento Object de XMLDSig para m&aacute;s informaci&oacute;n). Un uso incorrecto de este par&aacute;metro puede provocar la generaci&oacute;n de una firma inv&aacute;lida. Si se proporcionan datos a firmar previamente codificados en Base64 pero se desea sean considerados como su forma descodificada, debe establecerse este valor a http://www.w3.org/2000/09/xmldsig#base64 y especificarse el tipo real en el par&aacute;metro mimeType. Por ejemplo, para firmar una imagen PNG haciendo que la firma se refiera a su forma binaria directa, puede proporcionarse la imagen directamente codificada en Base64 indicando el encoding como http://www.w3.org/2000/09/xmldsig#base64 y el mimeType como image/png. El valor debe ser siempre una URI.</li>
+  	<li>URI con la codificaci&oacute;n de los datos a firmar (ver la  documentaci&oacute;n del elemento Object de XMLDSig para m&aacute;s informaci&oacute;n). Un uso incorrecto de esta propiedad puede provocar la generaci&oacute;n de una firma inv&aacute;lida. Si se proporcionan datos a firmar previamente codificados en Base64 pero se desea sean considerados como su forma descodificada, debe establecerse este valor a http://www.w3.org/2000/09/xmldsig#base64 y especificarse el tipo real en la propiedad <code>mimeType</code>. Por ejemplo, para firmar una imagen PNG haciendo que la firma se refiera a su forma binaria directa, puede proporcionarse la imagen directamente codificada en Base64 indicando el encoding como http://www.w3.org/2000/09/xmldsig#base64 y el mimeType como image/png. El valor debe ser siempre una URI.</li>
   </ul>
   <li style="margin-top: 10pt"><code>outputXmlEncoding</code>:</li>
   <ul>
@@ -311,7 +320,7 @@ Opciones:
   </ul>
   <li style="margin-top: 10pt"><code>contentTypeOid</code>:</li>
   <ul>
-  	<li>OID o URN de tipo OID con el identificador del tipo de dato firmado. Este par&aacute;metro es complementario (que no excluyente) al par&aacute;metro mimeType.</li>
+  	<li>OID o URN de tipo OID con el identificador del tipo de dato firmado. Esta propiedad es complementaria (que no excluyente) a la propiedad <code>mimeType</code>.</li>
   </ul>
   <li style="margin-top: 10pt"><code>canonicalizationAlgorithm</code>:</li>
   	<ul>
@@ -323,13 +332,13 @@ Opciones:
   <li style="margin-top: 10pt"><code>xadesNamespace</code>:</li>
   	<ul>
   	<li><code>http://uri.etsi.org/01903/v1.3.2#</code>:	URL de definici&oacute;n del espacio de nombres de XAdES correspondiente a la versi&oacute;n 1.3.2 de XAdES. Este es el valor por defecto.</li>
-  	<li><code>http://uri.etsi.org/01903/v1.4.1#</code>:	URL de definici&oacute;n del espacio de nombres de XAdES correspondiente a la versi&oacute;n 1.4.1 de XAdES. Si se establece este par&aacute;metro es posible que se necesite establecer tambi&eacute;n el par&aacute;metro signedPropertiesTypeUrl para evitar incoherencias en la versi&oacute;n de XAdES.</li>
+  	<li><code>http://uri.etsi.org/01903/v1.4.1#</code>:	URL de definici&oacute;n del espacio de nombres de XAdES correspondiente a la versi&oacute;n 1.4.1 de XAdES. Si se establece esta propiedad es posible que se necesite establecer tambi&eacute;n la propiedad <code>signedPropertiesTypeUrl</code> para evitar incoherencias en la versi&oacute;n de XAdES.</li>
 	</ul>
  <li style="margin-top: 10pt"><code>signedPropertiesTypeUrl</code>:</li>
   	<ul>
   	<li><code>http://uri.etsi.org/01903#SignedProperties</code>:	URL de definici&oacute;n del tipo de las propiedades firmadas (Signed Properties) de XAdES. Este es el valor por defecto.</li>
   	<li><code>http://uri.etsi.org/01903/1.3.2#SignedProperties</code>:	URL de definici&oacute;n del tipo de las propiedades firmadas (Signed Properties) de XAdES v1.3.2.</li>
-  	<li><code>http://uri.etsi.org/01903/1.4.1#SignedProperties</code>:	URL de definici&oacute;n del tipo de las propiedades firmadas (Signed Properties) de XAdES v1.4.1. Si se establece este par&aacute;metro es posible que se necesite establecer tambi&eacute;n el par&aacute;metro xadesNamespace para evitar incoherencias en la versi&oacute;n de XAdES.</li>
+  	<li><code>http://uri.etsi.org/01903/1.4.1#SignedProperties</code>:	URL de definici&oacute;n del tipo de las propiedades firmadas (Signed Properties) de XAdES v1.4.1. Si se establece esta propiedad es posible que se necesite establecer tambi&eacute;n la propiedad <code>xadesNamespace</code> para evitar incoherencias en la versi&oacute;n de XAdES.</li>
 	</ul>
   <li style="margin-top: 10pt"><code>ignoreStyleSheets</code>:</li>
   	<ul>
@@ -417,11 +426,11 @@ Opciones:
   </ul>	
   <li style="margin-top: 10pt"><code>xadesNamespace</code>:</li>
   <ul>
-  	<li>URL de definici&oacute;n del espacio de nombres de XAdES (el uso de este par&aacute;metro puede condicionar la declaraci&oacute;n de versi&oacute;n de XAdES). Si se establece este par&aacute;metro es posible que se necesite establecer tambi&eacute;n el par&aacute;metro signedPropertiesTypeUrl para evitar incoherencias en la versi&oacute;n de XAdES.</li>
+  	<li>URL de definici&oacute;n del espacio de nombres de XAdES (el uso de esta propiedad puede condicionar la declaraci&oacute;n de versi&oacute;n de XAdES). Si se establece esta propiedad es posible que se necesite establecer tambi&eacute;n la propiedad signedPropertiesTypeUrl para evitar incoherencias en la versi&oacute;n de XAdES.</li>
   </ul>	
   <li style="margin-top: 10pt"><code>signedPropertiesTypeUrl</code>:</li>
   <ul>
-  	<li>URL de definici&oacute;n del tipo de las propiedades firmadas (Signed Properties) de XAdES. Si se establece este par&aacute;metro es posible que se necesite establecer tambi&eacute;n el par&aacute;metro xadesNamespace para evitar incoherencias en la versi&oacute;n de XAdES. Si no se establece se usa el valor por defecto: http://uri.etsi.org/01903#SignedProperties.</li>
+  	<li>URL de definici&oacute;n del tipo de las propiedades firmadas (Signed Properties) de XAdES. Si se establece esta propiedad es posible que se necesite establecer tambi&eacute;n la propiedad <code>xadesNamespace</code> para evitar incoherencias en la versi&oacute;n de XAdES. Si no se establece se usa el valor por defecto: http://uri.etsi.org/01903#SignedProperties.</li>
   </ul>	
   <li style="margin-top: 10pt"><code>signerClaimedRoles</code>:</li>
   	<ul>
@@ -442,10 +451,10 @@ Opciones:
   </ul>	
   <li style="margin-top: 10pt"><code>policyIdentifierHashAlgorithm</code>:</li>
   	<ul>
-  	<li><code>SHA1</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA1.</li>
-  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-256.</li>
-  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-384.</li>
-  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-512.</li>
+  	<li><code>SHA1</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA1.</li>
+  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en la propiedad <code> policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-256.</li>
+  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-384.</li>
+  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-512.</li>
 	</ul>
   </ul>
 
@@ -585,7 +594,7 @@ Opciones:
   </ul>
   <li style="margin-top: 10pt"><code>image</code>:</li>
   <ul>
-  	<li>Ruta del fichero de imagen JPEG que insertar en el documento antes de firmarlo. Tambi&eacute;n puede indicarse directamente el Base 64 de la imagen. Este par&aacute;metro s&oacute;lo se puede utilizar en la primera firma del documento.</li>
+  	<li>Ruta del fichero de imagen JPEG que insertar en el documento antes de firmarlo. Tambi&eacute;n puede indicarse directamente el Base 64 de la imagen. Esta propiedad s&oacute;lo se puede utilizar en la primera firma del documento.</li>
   </ul>
   <li style="margin-top: 10pt"><code>imagePage</code>:</li>
   <ul>
@@ -668,14 +677,14 @@ Opciones:
   </ul>  
   <li style="margin-top: 10pt"><code>policyIdentifierHash</code>:</li>
   <ul>
-  	<li>Texto Base 64 con la huella digital de la pol&iacute;tica de firma. Es obligatorio indicar este par&aacute;metro si el valor indicado en policyIdentifier no es universalmente accesible. Si se da valor a este par&aacute;metro es obligatorio tambi&eacute;n dar valor al par&aacute;metro policyIdentifierHashAlgorithm.</li>
+  	<li>Texto Base 64 con la huella digital de la pol&iacute;tica de firma. Es obligatorio indicar esta propiedad si el valor indicado en policyIdentifier no es universalmente accesible. Si se da valor a esta propiedad es obligatorio tambi&eacute;n dar valor a la propiedad <code>policyIdentifierHashAlgorithm</code>.</li>
   </ul>
   <li style="margin-top: 10pt"><code>policyIdentifierHashAlgorithm</code>:</li>
   	<ul>
-  	<li><code>SHA1</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA1.</li>
-  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-256.</li>
-  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-384.</li>
-  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en el par&aacute;metro policyIdentifierHash se calcul&oacute; mediante el algoritmo SHA-512.</li>
+  	<li><code>SHA1</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA1.</li>
+  	<li><code>SHA-256</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-256.</li>
+  	<li><code>SHA-384</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-384.</li>
+  	<li><code>SHA-512</code>:	Indica que la huella digital indicada en la propiedad <code>policyIdentifierHash</code> se calcul&oacute; mediante el algoritmo SHA-512.</li>
 	</ul>
   <li style="margin-top: 10pt"><code>policyQualifier</code>:</li>
   <ul>


### PR DESCRIPTION
- Se agrega una nueva propiedad de configuración para las firmas CAdES generadas desde la web para indicarles que incluyan el atributo id-aa-ets-mimeType con el mimetype de los datos (atributo compatible con CAdES 2.1.1 y superiores, incluyendo firmas baseline). Si no se indica esta propiedad, no se agregará el atributo. El valor del mimetype puede indicarse a través de la propiedad "mimeType", se puede extrapolar de la propiedad contentTypeOid, se puede obtener de firmas anteriores (sólo para cofirmas) o del análisis de los datos. En caso de no identificar el tipo de datos, se usará el mimetype "application/octet-stream".
- Las contrafirmas nunca incluyen el mimetype.