### PR TITLE
Soporte para firefox-esr en debian y derivadas

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -59,6 +59,7 @@ final class MozillaKeyStoreUtilitiesUnix {
 		nssPaths.add(systemLibDir + "/nss"); //$NON-NLS-1$
 		nssPaths.add(systemLibDir);
 		nssPaths.add(systemLibDir + "/firefox"); //$NON-NLS-1$
+		nssPaths.add(systemLibDir + "/firefox-esr");//$NON-NLS-1$
 
 		// Preserve backwards-compatibility on https://github.com/ctt-gob-es/clienteafirma/issues/27#issuecomment-488402089
 		String firefoxVersion = searchLastFirefoxVersion(systemLibDir);


### PR DESCRIPTION
corrige la búsqueda del directorio de firefox esr en debian y derivadas.

Fix #252 