### PR TITLE
Evita NullPointerException al buscar keystore Firefox en algunos casos en Linux

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -154,9 +154,12 @@ final class MozillaKeyStoreUtilitiesUnix {
 
 			// Tomamos lo numeros de version de firefox identificados
 			final List<String> firefoxVersions = new ArrayList<>();
-			for (final String filename : directoryLib.list()) {
-				if (filename.startsWith("firefox-")) { //$NON-NLS-1$
-					firefoxVersions.add(filename.replace("firefox-", "")); //$NON-NLS-1$ //$NON-NLS-2$
+			final String[] filenames = directoryLib.list();
+			if (filenames != null) {
+				for (final String filename : directoryLib.list()) {
+					if (filename.startsWith("firefox-")) { //$NON-NLS-1$
+						firefoxVersions.add(filename.replace("firefox-", "")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
 				}
 			}
 


### PR DESCRIPTION
## Error a resolver

NullPointerException en MozillaKeyStoreUtilitiesUnix.searchLastFirefoxVersion en algunos casos.


## Resumen
Si intentamos buscar la versión de Firefox en un directorio que no tenemos permisos pero si que vemos, entonces da un NullPointerException, ya que el método isDirectory nos devuelve true pero el método list nos devuelve null, y se está suponiendo erróneamente que si isDirectory devuelve true, list devolverá un array

```java
if (directoryList.isDirectory() {
    // ...
    for (final String filename : directoryLib.list()) { // NPE aqui porque list() devuelve null
        // ...
    }
}
```

Relacionado con #252

## Detalles
Tenemos un directorio de otro usuario, del que no tenemos permisos, ejemplo:
     
    drwx------  2 root    root    4,0K mar  3 01:02 prueba


Si ejecutamos un programa con otro usuario que no sea root, el método
```java
file.isDirectory();
```
nos devuelve true, porque el directorio existe.

Pero al ejecutar 
```java
file.list();
```
Nos devuelve null.


Si bien la documentación de Java nos puede dar lugar a confusión, puesto que da a entender lo que pone el código actual: que si ```isDirectory()```devuelve true, ```list()``` no devolverá null. Sin embargo en este caso especial no es así, y es necesario poner la comprobación de nulo propuesta en esta Pull Request.

```txt
If this abstract pathname does not denote a directory, then this method returns null. 
Otherwise an array of strings is returned, one for each file or directory in the directory. 
```

traza en la versión 1.7.1 

```txt
Exception in thread "main" java.lang.ExceptionInInitializerError
at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilities.getSystemNSSLibDir(MozillaKeyStoreUtilities.java:251)
at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilities.loadNSS(MozillaKeyStoreUtilities.java:694)
at es.gob.afirma.keystores.mozilla.NssKeyStoreManager.getNssProvider(NssKeyStoreManager.java:122)
at es.gob.afirma.keystores.mozilla.NssKeyStoreManager.init(NssKeyStoreManager.java:59)
at es.gob.afirma.keystores.mozilla.MozillaUnifiedKeyStoreManager.init(MozillaUnifiedKeyStoreManager.java:75)
at es.gob.afirma.keystores.AOKeyStoreManagerFactory.getNssKeyStoreManager(AOKeyStoreManagerFactory.java:511)
at es.gob.afirma.keystores.AOKeyStoreManagerFactory.getMozillaUnifiedKeyStoreManager(AOKeyStoreManagerFactory.java:542)
at es.gob.afirma.keystores.AOKeyStoreManagerFactory.getAOKeyStoreManager(AOKeyStoreManagerFactory.java:133)
at es.gob.afirma.standalone.SimpleAfirma.main(SimpleAfirma.java:708)
Caused by: java.lang.NullPointerException
at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilitiesUnix.searchLastFirefoxVersion(MozillaKeyStoreUtilitiesUnix.java:145)
at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilitiesUnix.getNssPaths(MozillaKeyStoreUtilitiesUnix.java:78)
at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilitiesUnix.(MozillaKeyStoreUtilitiesUnix.java:26)
... 9 more
```

