### PR TITLE
Establece version TLS a 1.2

### DIFF
--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/SecureSocketUtils.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/SecureSocketUtils.java
@@ -24,7 +24,7 @@ class SecureSocketUtils {
 	private static final String KEYSTORE_NAME = "autofirma.pfx"; //$NON-NLS-1$
 	private static final String CA_ROOT_NAME = "AutoFirma_ROOT.cer"; //$NON-NLS-1$
 	private static final String PKCS12 = "PKCS12"; //$NON-NLS-1$
-	private static final String SSLCONTEXT = "TLSv1"; //$NON-NLS-1$
+	private static final String SSLCONTEXT = "TLSv1.2"; //$NON-NLS-1$
 
 	/**
 	 * Obtiene un contexto SSL para la apertura de un socket/websocket seguro.


### PR DESCRIPTION
Con esto hacemos que se creen correctamente los contextos TLS con las configuraciones de servidores y de java actuales, sin necesidad de configurar manualmente java.security.

Fix #265
Fix #307