### PR TITLE
Update autofirma.spec

### DIFF
--- a/afirma-simple-installer/linux/instalador_rpm_suse/rpmbuild/SPECS/autofirma.spec
+++ b/afirma-simple-installer/linux/instalador_rpm_suse/rpmbuild/SPECS/autofirma.spec
@@ -49,6 +49,7 @@ MimeType=x-scheme-handler/afirma
 EOF
 
 cat > %{name} <<EOF
+#!/bin/bash
 java -Djdk.tls.maxHandshakeMessageSize=50000 -jar %{_libdir}/%{name}/%{name}.jar "\$@"
 EOF
 


### PR DESCRIPTION
El lanzador no funciona desde el menú de aplicaciones de kde (al menos) si no se especifica el interprete, dando error de ejecutable. Sí que funciona si se lanza desde una consola. Probado el cambio en OpenSuse Tumbleweed. _Sería interesante comprobar si es necesaria esta modificación para que el lanzador funcione en otras distribuciones/entornos de escritorio_.

He revisado el spec para Fedora, y ya incluye la modificación propuesta.

Fix #288