### PR TITLE
fix: null pointer exception si no se tiene permiso para leer directorio de bibliotecas

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -154,27 +154,32 @@ final class MozillaKeyStoreUtilitiesUnix {
 
 			// Tomamos lo numeros de version de firefox identificados
 			final List<String> firefoxVersions = new ArrayList<>();
-			for (final String filename : directoryLib.list()) {
-				if (filename.startsWith("firefox-")) { //$NON-NLS-1$
-					firefoxVersions.add(filename.replace("firefox-", "")); //$NON-NLS-1$ //$NON-NLS-2$
+			final String[] fileList = directoryLib.list();
+			if (fileList != null) {
+				for (final String filename : fileList) {
+					if (filename.startsWith("firefox-")) { //$NON-NLS-1$
+						firefoxVersions.add(filename.replace("firefox-", "")); //$NON-NLS-1$ //$NON-NLS-2$
+					}
 				}
-			}
 
-			// Calculamos el numero de version mayor
-			for (final String versionText : firefoxVersions) {
-				Version version;
-				try {
-					version = new Version(versionText);
+				// Calculamos el numero de version mayor
+				for (final String versionText : firefoxVersions) {
+					Version version;
+					try {
+						version = new Version(versionText);
+					}
+					catch (final Exception e) {
+						LOGGER.warning(
+							"Se encontro un numero de version de Firefox no soportado (" + versionText + "): " + e //$NON-NLS-1$ //$NON-NLS-2$
+						);
+						continue;
+					}
+					if (maxVersion == null || version.compareTo(maxVersion) > 0) {
+						maxVersion = version;
+					}
 				}
-				catch (final Exception e) {
-					LOGGER.warning(
-						"Se encontro un numero de version de Firefox no soportado (" + versionText + "): " + e //$NON-NLS-1$ //$NON-NLS-2$
-					);
-					continue;
-				}
-				if (maxVersion == null || version.compareTo(maxVersion) > 0) {
-					maxVersion = version;
-				}
+			} else {
+				 LOGGER.warning("No se pudo listar el directorio " + directoryLib.getAbsolutePath());
 			}
 		}
 		return maxVersion != null ? maxVersion.toString() : null;


### PR DESCRIPTION
En linux, si alguno de los directorios donde se busca firefox es innacesible por falta de permisos se eleva la siguiente excepción:

```
INFO: Inicializamos el almacen de tipo: NSS
Exception in thread "main" java.lang.ExceptionInInitializerError
        at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilities.getSystemNSSLibDir(MozillaKeyStoreUtilities.java:252)
        at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilities.loadNSS(MozillaKeyStoreUtilities.java:706)
        at es.gob.afirma.keystores.mozilla.NssKeyStoreManager.getNssProvider(NssKeyStoreManager.java:122)
        at es.gob.afirma.keystores.mozilla.NssKeyStoreManager.init(NssKeyStoreManager.java:59)
        at es.gob.afirma.keystores.mozilla.MozillaUnifiedKeyStoreManager.init(MozillaUnifiedKeyStoreManager.java:77)
        at es.gob.afirma.keystores.AOKeyStoreManagerFactory.getNssKeyStoreManager(AOKeyStoreManagerFactory.java:511)
        at es.gob.afirma.keystores.AOKeyStoreManagerFactory.getMozillaUnifiedKeyStoreManager(AOKeyStoreManagerFactory.java:542)
        at es.gob.afirma.keystores.AOKeyStoreManagerFactory.getAOKeyStoreManager(AOKeyStoreManagerFactory.java:133)
        at es.gob.afirma.standalone.SimpleAfirma.main(SimpleAfirma.java:739)
Caused by: java.lang.NullPointerException: Cannot read the array length because "<local4>" is null
        at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilitiesUnix.searchLastFirefoxVersion(MozillaKeyStoreUtilitiesUnix.java:157)
        at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilitiesUnix.getNssPaths(MozillaKeyStoreUtilitiesUnix.java:87)
        at es.gob.afirma.keystores.mozilla.MozillaKeyStoreUtilitiesUnix.<clinit>(MozillaKeyStoreUtilitiesUnix.java:32)
        ... 9 more
```

Esta modificación comprueba que se ha podido listar el directorio.