### PR TITLE
Update XmpHelper.java

### DIFF
--- a/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/XmpHelper.java
+++ b/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/XmpHelper.java
@@ -68,30 +68,62 @@ final class XmpHelper {
 			"  <stEvt:when>" + TAG_DATE + "</stEvt:when>\n" + //$NON-NLS-1$ //$NON-NLS-2$
 			"</rdf:li>"; //$NON-NLS-1$
 
-	private static String getOriginalCreationDateAsW3C(final byte[] inPdf) {
-		final String pdfStr = new String(inPdf);
-
-		int pos = pdfStr.indexOf("/CreationDate"); //$NON-NLS-1$
-		if (pos == -1) {
-			return null;
-		}
-		pos += "/CreationDate".length(); //$NON-NLS-1$
-
-		pos = pdfStr.indexOf("(", pos); //$NON-NLS-1$
-		if (pos == -1) {
-			return null;
-		}
-		pos += "(".length(); //$NON-NLS-1$
-		final int pos2 = pdfStr.indexOf(")", pos); //$NON-NLS-1$
-		if (pos2 == -1) {
-			return null;
-		}
-		final String pdfDateStr = pdfStr.substring(pos, pos2).trim();
-		return PdfDate.getW3CDate(
-			pdfDateStr
-		);
-	}
-
+	  /**
+	   *  B&uacute;squeda de subcadenas en arrays de bytes. Similar al m&eacute;todo de Google Guava en la clase Bytes.
+	   *
+	   * @param inPdf
+	   * @return
+	   */
+	  public static int indexOf(byte[] array, byte[] target, int start) {
+	    if (target.length == 0) {
+	      return 0;
+	    }
+	
+	    outer:
+	    for (int i = start; i < array.length - target.length + 1; i++) {
+	      for (int j = 0; j < target.length; j++) {
+	        if (array[i + j] != target[j]) {
+	          continue outer;
+	        }
+	      }
+	      return i;
+	    }
+	    return -1;
+	  }
+	
+	  /**
+	   *  Obtener la fecha de creaci&oactue;n del PDF.
+	   *
+	   * @param inPdf
+	   * @return
+	   */
+	  public static String getOriginalCreationDateAsW3C(final byte[] inPdf) {
+	    byte[] aCreation = "/CreationDate".getBytes();
+	    byte[] aOpen = "(".getBytes();
+	    byte[] aClose = ")".getBytes();
+	
+	    int pos = indexOf(inPdf, aCreation, 0);
+	    if (pos == -1) {
+	      return null;
+	    }
+	    pos += aCreation.length;
+	
+	    pos = indexOf(inPdf, aOpen, pos);
+	    if (pos == -1) {
+	      return null;
+	    }
+	    pos += aOpen.length;
+	
+	    final int pos2 = indexOf(inPdf, aClose, pos);
+	    if (pos2 == -1) {
+	      return null;
+	    }
+	
+	    System.out.println(pos + ", " + pos2);
+	    final String pdfDateStr = new String(Arrays.copyOfRange(inPdf, pos, pos2)).trim();
+	    return PdfDate.getW3CDate(pdfDateStr);
+	  }
+	
 	/** A&ntilde;ade una entrada de firma al hist&oacute;rico XMP de un PDF.
 	 * Un ejemplo de hist&oacute;rico XML con entrada de firma podr&iacute;a ser:
 	 * <pre>


### PR DESCRIPTION
Método getOriginalCreationDateAsW3C optimizado para ficheros PDF de gran tamaño.

Realizando pruebas de rendimiento con la firma de documentos PDF hemos detectado que se consume una gran cantidad de tiempo el este método, que se llama desde preSign y postSign.

Con estos cambios se reduce significativamente el tiempo empleado en la firma de documentos PDF de gran tamaño.

