### PR TITLE
Fix errors in desktop file according to the spec

### DIFF
--- a/afirma-simple-installer/linux/instalador_deb/src/usr/share/applications/afirma.desktop
+++ b/afirma-simple-installer/linux/instalador_deb/src/usr/share/applications/afirma.desktop
@@ -1,14 +1,12 @@
 [Desktop Entry]
-Encoding=UTF-8
-Version=1.9.0
+Version=1.5
 Name=AutoFirma
 Type=Application
 Terminal=false
-Categories=Office;Utilities;Signature;Java
+Categories=Office;Utility;Java
 Exec=/usr/bin/autofirma %u
 Icon=/usr/lib/AutoFirma/AutoFirma.png
 GenericName=Herramienta de firma
-Comment=Herramienta de firma
 MimeType=x-scheme-handler/afirma;
 StartupNotify=true
 StartupWMClass=autofirma


### PR DESCRIPTION
- Version is used as the Spec version, not the app's version. See [1]
- There is no Signature Category and Utilities should be Utility. See [2] and [3]
- Comment should not be rebundant with GenericName. See [1]
- Encoding is deprecated. See [4] [1]: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys [2]:https://specifications.freedesktop.org/menu-spec/latest/apa.html [3]:https://specifications.freedesktop.org/menu-spec/latest/apas02.html [4]:https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#legacy-mixed