### PR TITLE
Convertir SigningTime a Date teniendo en cuenta la zona horaria

### DIFF
--- a/afirma-crypto-core-xml/src/main/java/es/gob/afirma/signers/xml/Utils.java
+++ b/afirma-crypto-core-xml/src/main/java/es/gob/afirma/signers/xml/Utils.java
@@ -569,7 +569,7 @@ public final class Utils {
         	final Element signingTimeElement = (Element) signature.getElementsByTagNameNS(namespace, "SigningTime").item(0); //$NON-NLS-1$
         	if (signingTimeElement != null) {
         		try {
-        			signingTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse( //$NON-NLS-1$
+        			signingTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse( //$NON-NLS-1$
         					signingTimeElement.getTextContent()
         					);
         		}


### PR DESCRIPTION
El SigningTime de las firmas XML generadas por Autofirma y otros proveedores tienen el formato ISO8601. Cuando se obtiene el objeto AOSimpleSignInfo el instante de firma no está teniendo en cuenta la zona horaria y eso provoca que en ciertos casos el objeto Date resultante no representa correctamente la hora de la firma. Por ejemplo, 2024-10-23T08:00:00Z no será correctamente transformado en zonas horarias como canarias.