### PR TITLE
Se permite indicar varias páginas para la marca visible.

### DIFF
--- a/afirma-crypto-pdf-common/src/main/java/es/gob/afirma/signers/pades/common/PdfExtraParams.java
+++ b/afirma-crypto-pdf-common/src/main/java/es/gob/afirma/signers/pades/common/PdfExtraParams.java
@@ -115,14 +115,22 @@ public final class PdfExtraParams {
 	public static final String IMAGE = "image";//$NON-NLS-1$
 
 	/**
-	 * P&aacute;gina donde desea insertarse la imagen indicada mediante el
+	 * P&aacute;ginas donde desea insertarse la imagen indicada mediante el
 	 * par&aacute;metro <code>image</code>. La numeraci&oacute;n de las
 	 * p&aacute;ginas comienza en uno.<br>
-	 * Si se indica <i>-1</i> como n&uacute;mero de p&aacute;gina se inserta la
-	 * imagen en la &uacute;ltima p&aacute;gina del documento. Si se indica <i>0</i>
-	 * como n&uacute;mero de p&aacute;gina se inserta la imagen en todas las
-	 * p&aacute;ginas del documento. Este par&aacute;metro es obligatorio, si no se
-	 * indica una p&aacute;gina v&aacute;lida no se insertar&aacute; la imagen.
+	 * Se podr&aacute;n seleccionar todas las p&aacute;ginas usando la palabra clave {@code all} o
+	 * indicando <i>0</i> como n&uacute;mero de p&aacute;gina.
+	 * Se podr&aacute;n seleccionar p&aacute;ginas individuales list&aacute;ndolas separadas por comas (,).
+	 * Por ejemplo, para insertar la imagen en las p&aacute;ginas 1, 2, 5 y 7, se usar&aacute;: 1,2,5,7
+	 * Se podr&aacute;n seleccionar rangos de p&aacute;ginas separadas por guion (-), en donde en las dos p&aacute;ginas
+	 * que limitan el rango tambi&eacute;n se insertar&aacute; la imagen.
+	 * Por ejemplo, para insertar la imagen en las p&aacute;ginas 2, 3, 4 y 5, se usar&aacute;: 2-5
+	 * Se podr&aacute;n seleccionar p&aacute;ginas contando desde el final del documento utilizando valores negativos.
+	 * Por ejemplo, para insertar la imagen en la pen&uacute;ltima p&aacute;gina, se usar&aacute;: -2
+	 * Estos mecanismos podr&aacute;n usarse de forma conjunta, a excepci&oacute;n de la palabra clave {@code all}
+	 * o el <i>0</i> que ya implica la imagen en todas las p&aacute;ginas.
+	 * Por ejemplo, para insertar la imagen en las tres primeras p&aacute;ginas y en las tres &uacute;ltimas, se usar&aacute;: 1-3,-3--1
+	 * Este par&aacute;metro es obligatorio, si no se indica una p&aacute;gina v&aacute;lida no se insertar&aacute; la imagen.
 	 */
 	public static final String IMAGE_PAGE = "imagePage";//$NON-NLS-1$
 

--- a/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfPreProcessor.java
+++ b/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfPreProcessor.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -227,29 +228,10 @@ public final class PdfPreProcessor {
 			return;
 		}
 
-		int pageNum;
-		try {
-			pageNum = Integer.parseInt(imagePage.trim());
-		}
-		catch(final NumberFormatException e) {
-			throw new IOException(
-				"Se ha indicado un numero de pagina con formato invalido para insertar la imagen (" + imagePage + "): " + e, e //$NON-NLS-1$ //$NON-NLS-2$
-			);
-		}
+		final int totalPages = pdfReader.getNumberOfPages();
+		final List<Integer> pages = PdfUtil.getImagePages(extraParams, totalPages);
 
-		if (pageNum == LAST_PAGE) {
-			pageNum = pdfReader.getNumberOfPages();
-		}
-		final int pageLimit;
-		if (pageNum == ALL_PAGES) {
-			pageNum = FIRST_PAGE;
-			pageLimit = pdfReader.getNumberOfPages();
-		}
-		else {
-			pageLimit = pageNum;
-		}
-
-		for (int i= pageNum; i<=pageLimit; i++) {
+		for (int i : pages) {
 			addImage(
 				image,
 				(int) rect.getWidth(),

--- a/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
+++ b/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/PdfUtil.java
@@ -731,4 +731,45 @@ public final class PdfUtil {
 
 		return pages;
 	}
+
+    /**
+     * Obtiene el listado de p&aacute;ginas del documento donde se ha pedido insertar la imagen.
+     * @param extraParams Propiedades con la configuracion de firma de las que extraer
+     * las p&aacute;ginas.
+     * @param totalPages N&oacute;mero la &uacute;ltima p&aacute;gina del documento.
+     * @return P&aacute;ginas del documento.
+     */
+	public static List<Integer> getImagePages(final Properties extraParams, final int totalPages) {
+
+		final String[] pagesStr = extraParams.containsKey(PdfExtraParams.IMAGE_PAGE)
+				? extraParams.getProperty(PdfExtraParams.IMAGE_PAGE).split(RANGE_SEPARATOR)
+				: new String[0];
+
+		final List<Integer> pages = new ArrayList<>();
+
+		if (pagesStr.length != 0) {
+
+			// El valor ALL_PAGES o 0 pide que se inserte la imagen en todas las paginas
+			if ("0".equals(pagesStr[0].trim()) || ALL_PAGES.equalsIgnoreCase(pagesStr[0].trim())) { //$NON-NLS-1$
+				for (int page = 1; page <= totalPages; page++) {
+					pages.add(page);
+				}
+			// Rellenamos con las paginas y rangos indicados, evitando que se indiquen
+			// paginas posteriores a la ultima
+			} else {
+				for (final String pageStr : pagesStr) {
+					try {
+						getPagesRange(pageStr, totalPages, pages);
+					} catch (final IncorrectPageException e) {
+						LOGGER.log(Level.WARNING, "Se ha indicado un numero o rango de paginas para imagen invalido. Se ignorara.", e); //$NON-NLS-1$
+					}
+				}
+				// Ordenamos el listado de paginas
+				Collections.sort(pages);
+			}
+
+		}
+
+		return pages;
+	}
 }

--- a/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/doc-files/extraparams.html
+++ b/afirma-crypto-pdf/src/main/java/es/gob/afirma/signers/pades/doc-files/extraparams.html
@@ -54,11 +54,20 @@
     Si el documento ya contiene firmas es posible que se invaliden, por lo que conviene usarlo &uacute;nicamente en documentos sin firmas previas.
    </dd>
   <dt><b><i>imagePage</i></b></dt>
-   <dd>
-    P&aacute;gina donde desea insertarse la imagen indicada mediante el par&aacute;metro <code>image</code>. La numeraci&oacute;n de las p&aacute;ginas
+  <dd>
+    P&aacute;ginas donde desea insertarse la imagen indicada mediante el par&aacute;metro <code>image</code>. La numeraci&oacute;n de las p&aacute;ginas
     comienza en uno.<br>
-    Si se indica <i>-1</i> como n&uacute;mero de p&aacute;gina se inserta la imagen en la &uacute;ltima p&aacute;gina del documento.
-    Si se indica <i>0</i> como n&uacute;mero de p&aacute;gina se inserta la imagen en todas las p&aacute;ginas del documento.
+    Se podr&aacute;n seleccionar todas las p&aacute;ginas usando la palabra clave <code>all</code> o indicando <i>0</i> como n&uacute;mero de p&aacute;gina.
+    Se podr&aacute;n seleccionar p&aacute;ginas individuales list&aacute;ndolas separadas por comas (,).
+    Por ejemplo, para insertar la imagen en las p&aacute;ginas 1, 2, 5 y 7, se usar&aacute;: 1,2,5,7
+    Se podr&aacute;n seleccionar rangos de p&aacute;ginas separadas por guion (-), en donde en las dos p&aacute;ginas
+    que limitan el rango tambi&eacute;n se insertar&aacute; la imagen.
+    Por ejemplo, para insertar la imagen en las p&aacute;ginas 2, 3, 4 y 5, se usar&aacute;: 2-5
+    Se podr&aacute;n seleccionar p&aacute;ginas contando desde el final del documento utilizando valores negativos.
+    Por ejemplo, para insertar la imagen en la pen&uacute;ltima p&aacute;gina, se usar&aacute;: -2
+    Estos mecanismos podr&aacute;n usarse de forma conjunta, a excepci&oacute;n de la palabra clave <code>all</code>
+    o el <i>0</i> que ya implica la imagen en todas las p&aacute;ginas.
+    Por ejemplo, para insertar la imagen en las tres primeras p&aacute;ginas y en las tres &uacute;ltimas, se usar&aacute;: 1-3,-3--1
     Este par&aacute;metro es obligatorio, si no se indica una p&aacute;gina v&aacute;lida no se insertar&aacute; la imagen.
    </dd> 
   <dt><b><i>imagePositionOnPageLowerLeftX</i></b></dt>

--- a/afirma-simple/src/main/resources/help/Spanish.lproj/pgs/LineaComandos.html
+++ b/afirma-simple/src/main/resources/help/Spanish.lproj/pgs/LineaComandos.html
@@ -616,8 +616,10 @@ Opciones:
   <li style="margin-top: 10pt"><code>imagePage</code>:</li>
   <ul>
   	<li>N&uacute;mero de la p&aacute;gina del documento PDF en la que insertar la imagen.</li>
-  	<li><code>0</code>: Insertar en todas las p&aacute;ginas</li>
+  	<li><code>0</code> o <code>all</code>: Insertar en todas las p&aacute;ginas</li>
   	<li><code>-1</code>: Insertar imagen en la &uacute;ltima p&aacute;gina.</li>
+  	<li>Se pueden indicar rangos de p&aacute;ginas separadas por guion (-). Por ejemplo: <code>2-5</code>.</li>
+  	<li>Se pueden indicar p&aacute;ginas individuales list&aacute;ndolas separadas por comas. Por ejemplo: <code>1,5,7</code>.</li>
   </ul>
   <li style="margin-top: 10pt"><code>imagePositionOnPageLowerLeftX</code>:</li>
   <ul>

--- a/afirma-simple/src/main/resources/properties/signpdfuimessages.properties
+++ b/afirma-simple/src/main/resources/properties/signpdfuimessages.properties
@@ -130,6 +130,7 @@ SignPdfUiStamp.24=Anchura de la firma
 SignPdfUiStamp.25=Altura de la firma
 SignPdfUiStamp.26=Inserte o seleccione el \u00E1rea para la imagen de marca visible.
 SignPdfUiStamp.27=Inserte las coordenadas y el tama\u00F1o del \u00E1rea de la imagen de marca visible.
+SignPdfUiStamp.28=<html><b>P\u00E1gina de marca</b></html>
 SignPdfUiStamp.3=X:
 SignPdfUiStamp.4=Y:
 SignPdfUiStamp.5=Previsualizaci\u00F3n de la p\u00E1gina actual del PDF


### PR DESCRIPTION
# Motivación
 Me ha surgido la necesidad de poner la marca visible en varias páginas. Actualmente solo se permite una página determinada, todas, o la última.

# Cambios
He modificado el parámetro `imagePage` para que funcione de modo similar al `signaturePage` pero sin la posibilidad de indicar el valor append. Sigue siendo posible usar 0 para indicar todas las páginas, -1 para la última, o una página específica. Pero, además, con esta modificación también se permite indicar all (para todas las páginas, por coherencia con signaturePage), o páginas/rangos separados por comas.

He ajustado el cuadro de diálogo «Propiedades de marca visible» para que permita indicar rangos de páginas del mismo modo que el cuadro de diálogo «Propiedades de la firma visible».

## Nota 1
Al igual que como se está haciendo actualmente con algunas propiedades de mensajes, he mantenido las propiedades de los mensajes en su cuadro de diálogo original en lugar de copiarlos al modificado. Se está haciendo con mensajes como el SignPdfUiPreview.21. Como no estoy seguro de qué criterios se usan, he usado mensajes como el SignPdfUiPanel.24 en lugar de copiarlos a nuevas entradas en SignPdfUiStamp. Pero he creado el mensaje SignPdfUiStamp.28 = Página de marca (para diferenciarlo del texto Página de firma del otro cuadro de diálogo).

## Nota 2
Aunque he actualizado textos de ayuda, falta actualizar la de la interfaz de usuario (que requiere una captura de pantalla).