### PR TITLE
Compatiblidad Linux ARM64 (aarch64-linux)

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/bintutil/ElfParser.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/bintutil/ElfParser.java
@@ -139,8 +139,10 @@ public final class ElfParser {
 			return false;
 		}
 		return "64".equals(Platform.getJavaArch()) && //$NON-NLS-1$
-					Platform.MACHINE.AMD64.equals(Platform.getMachineType()) &&
+					(Platform.MACHINE.AMD64.equals(Platform.getMachineType()) &&
 						ElfMachineType.AMD64.equals(a) ||
+					Platform.MACHINE.ARM64.equals(Platform.getMachineType()) &&
+						ElfMachineType.ARM64.equals(a)) ||
 			   "32".equals(Platform.getJavaArch()) && //$NON-NLS-1$
 			   		(Platform.MACHINE.X86.equals(Platform.getMachineType()) || Platform.MACHINE.AMD64.equals(Platform.getMachineType())) && // 32 puede estar en maquina de 32 o de 64 bits
 		   				ElfMachineType.X86.equals(a);


### PR DESCRIPTION
Se añade a la comprobación la arquitectura ARM64 para permitir la carga del NSS en Linux aarch64.

El cambio se ha compilado y comprobado con la versión actual 1.8.4 en un Linux con arquitectura aarch64 y ha funcionado correctamente la integración con Firefox.

https://github.com/nix-community/autofirma-nix/pull/108