### PR TITLE
Añadir comprobaciones File.canRead

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -17,6 +17,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import es.gob.afirma.core.misc.LoggerUtil;
@@ -150,11 +151,11 @@ final class MozillaKeyStoreUtilitiesUnix {
 
 		Version maxVersion = null;
 		final File directoryLib = new File(startDir);
-		if (directoryLib.isDirectory()) {
+		if (directoryLib.isDirectory() && directoryLib.canRead()) {
 
 			// Tomamos lo numeros de version de firefox identificados
 			final List<String> firefoxVersions = new ArrayList<>();
-			for (final String filename : directoryLib.list()) {
+			for (final String filename : Objects.requireNonNull(directoryLib.list())) {
 				if (filename.startsWith("firefox-")) { //$NON-NLS-1$
 					firefoxVersions.add(filename.replace("firefox-", "")); //$NON-NLS-1$ //$NON-NLS-2$
 				}

--- a/afirma-simple-plugin-hash/src/main/java/es/gob/afirma/plugin/hash/HashPlugin.java
+++ b/afirma-simple-plugin-hash/src/main/java/es/gob/afirma/plugin/hash/HashPlugin.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -122,8 +123,8 @@ public class HashPlugin extends AfirmaPlugin {
 	 * @throws IOException Cuando ocurre un error al eliminar el elemento.
 	 */
 	private static void deleteFile(final File file) throws IOException {
-		if (file.isDirectory()) {
-			for (final File subFile : file.listFiles()) {
+		if (file.isDirectory() && file.canRead()) {
+			for (final File subFile : Objects.requireNonNull(file.listFiles())) {
 				deleteFile(subFile);
 			}
 		}


### PR DESCRIPTION
En algunas comprobaciones de nombres de directorios para ver si existen hay que comprobar también si se tiene acceso a leer su contenido (especialmente en Linux). Se usa para ello File.canRead.

Además conviene verificar que los objetos File que se pretendan enumerar se han creado correctamente para evitar una excepción no controlada de puntero nulo que sin el .canRead anterior se daría con toda seguridad.