### PR TITLE
Corrección en la configuración de preferencias

### DIFF
--- a/afirma-ui-simple-configurator-common/src/main/resources/properties/preferences.properties
+++ b/afirma-ui-simple-configurator-common/src/main/resources/properties/preferences.properties
@@ -108,6 +108,7 @@ pdfSignatureImage =
 #Panel Almacenes de Claves
 showExpiredCerts = false
 hideDnieStartScreen = false
+useDefaultStoreInBrowserCalls =
 useOnlySignatureCertificates =  false
 useOnlyAliasCertificates = false
 skipAuthCertDnie = true

--- a/afirma-ui-simple-configurator-common/src/main/resources/properties/preferences.properties
+++ b/afirma-ui-simple-configurator-common/src/main/resources/properties/preferences.properties
@@ -102,6 +102,7 @@ pdfSignatureImage =
 #Panel Almacenes de Claves
 showExpiredCerts = false
 hideDnieStartScreen = false
+useDefaultStoreInBrowserCalls = false
 useOnlySignatureCertificates =  false
 useOnlyAliasCertificates = false
 skipAuthCertDnie = true


### PR DESCRIPTION
Se añade un valor¹ que no estaba presente en el fichero `preferences.properties`.

**NOTA**: Este cambio también aplica a la rama `develop`; sugiero hacer un cherry-pick del mismo, o bien puedo abrir otra PR contra la rama `develop`.

La discrepancia ha salido a la luz gracias a https://github.com/nix-community/autofirma-nix/pull/782.

¹: `useDefaultStoreInBrowserCalls`, presente en [PreferencesManager.java](https://github.com/ctt-gob-es/clienteafirma/blob/d3d039512d4adb7ac0d67e9e3d1ce6024b2efd88/afirma-ui-simple-configurator-common/src/main/java/es/gob/afirma/standalone/configurator/common/PreferencesManager.java#L556)

Muchas gracias, y recibid un cordial saludo.