### PR TITLE
fix(installer): eliminar instalaciones previas antes de instalar en macOS

### DIFF
--- a/afirma-simple-installer/macos/Autofirma_Packages_aarch64/Autofirma.pkgproj
+++ b/afirma-simple-installer/macos/Autofirma_Packages_aarch64/Autofirma.pkgproj
@@ -493,6 +493,8 @@
 				</dict>
 				<key>PREINSTALL_PATH</key>
 				<dict>
+					<key>PATH</key>
+					<string>scripts/preinstall</string>
 					<key>PATH_TYPE</key>
 					<integer>1</integer>
 				</dict>

--- a/afirma-simple-installer/macos/Autofirma_Packages_aarch64/scripts/preinstall
+++ b/afirma-simple-installer/macos/Autofirma_Packages_aarch64/scripts/preinstall
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Eliminamos cualquier instalacion previa de la aplicacion antes de copiar la nueva.
+#
+# En sistemas de archivos que no distinguen mayusculas de minusculas (APFS por
+# defecto en macOS), el nuevo paquete "Autofirma.app" se fusionaria con un
+# "AutoFirma.app" antiguo (nomenclatura de versiones anteriores a la 1.9) en
+# lugar de sustituirlo. El bundle resultante contiene ficheros obsoletos que
+# invalidan el sello de la firma de codigo ("a sealed resource is missing or
+# invalid") y Gatekeeper impide abrir la aplicacion tras el primer reinicio.
+for APP_DIR in "/Applications/Autofirma.app" "/Applications/AutoFirma.app"; do
+	if [ -d "$APP_DIR" ]; then
+		rm -rf "$APP_DIR"
+	fi
+done
+
+exit 0

--- a/afirma-simple-installer/macos/Autofirma_Packages_for_old_systems/Autofirma.pkgproj
+++ b/afirma-simple-installer/macos/Autofirma_Packages_for_old_systems/Autofirma.pkgproj
@@ -477,6 +477,8 @@
 				</dict>
 				<key>PREINSTALL_PATH</key>
 				<dict>
+					<key>PATH</key>
+					<string>scripts/preinstall</string>
 					<key>PATH_TYPE</key>
 					<integer>1</integer>
 				</dict>

--- a/afirma-simple-installer/macos/Autofirma_Packages_for_old_systems/scripts/preinstall
+++ b/afirma-simple-installer/macos/Autofirma_Packages_for_old_systems/scripts/preinstall
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Eliminamos cualquier instalacion previa de la aplicacion antes de copiar la nueva.
+#
+# En sistemas de archivos que no distinguen mayusculas de minusculas (APFS por
+# defecto en macOS), el nuevo paquete "Autofirma.app" se fusionaria con un
+# "AutoFirma.app" antiguo (nomenclatura de versiones anteriores a la 1.9) en
+# lugar de sustituirlo. El bundle resultante contiene ficheros obsoletos que
+# invalidan el sello de la firma de codigo ("a sealed resource is missing or
+# invalid") y Gatekeeper impide abrir la aplicacion tras el primer reinicio.
+for APP_DIR in "/Applications/Autofirma.app" "/Applications/AutoFirma.app"; do
+	if [ -d "$APP_DIR" ]; then
+		rm -rf "$APP_DIR"
+	fi
+done
+
+exit 0

--- a/afirma-simple-installer/macos/Autofirma_Packages_x64/Autofirma.pkgproj
+++ b/afirma-simple-installer/macos/Autofirma_Packages_x64/Autofirma.pkgproj
@@ -493,6 +493,8 @@
 				</dict>
 				<key>PREINSTALL_PATH</key>
 				<dict>
+					<key>PATH</key>
+					<string>scripts/preinstall</string>
 					<key>PATH_TYPE</key>
 					<integer>1</integer>
 				</dict>

--- a/afirma-simple-installer/macos/Autofirma_Packages_x64/scripts/preinstall
+++ b/afirma-simple-installer/macos/Autofirma_Packages_x64/scripts/preinstall
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Eliminamos cualquier instalacion previa de la aplicacion antes de copiar la nueva.
+#
+# En sistemas de archivos que no distinguen mayusculas de minusculas (APFS por
+# defecto en macOS), el nuevo paquete "Autofirma.app" se fusionaria con un
+# "AutoFirma.app" antiguo (nomenclatura de versiones anteriores a la 1.9) en
+# lugar de sustituirlo. El bundle resultante contiene ficheros obsoletos que
+# invalidan el sello de la firma de codigo ("a sealed resource is missing or
+# invalid") y Gatekeeper impide abrir la aplicacion tras el primer reinicio.
+for APP_DIR in "/Applications/Autofirma.app" "/Applications/AutoFirma.app"; do
+	if [ -d "$APP_DIR" ]; then
+		rm -rf "$APP_DIR"
+	fi
+done
+
+exit 0


### PR DESCRIPTION
Corrige #524.

## Problema

En APFS (sin distinción de mayúsculas por defecto), el paquete de macOS instala `Autofirma.app` sobre un `AutoFirma.app` antiguo (nomenclatura de versiones ≤ 1.8.x) fusionando ambos bundles en lugar de sustituirlo. Los ficheros obsoletos de la versión anterior invalidan el sello de la firma de código (`codesign -vv` devuelve *"a sealed resource is missing or invalid"*) y Gatekeeper impide abrir la aplicación tras el primer reinicio.

## Cambios

- Nuevo script `preinstall` en los tres proyectos de paquete de macOS (`Autofirma_Packages_aarch64`, `Autofirma_Packages_x64` y `Autofirma_Packages_for_old_systems`) que elimina cualquier bundle previo en `/Applications` (con ambas grafías) antes de copiar el payload.
- Registro del script en la clave `PREINSTALL_PATH` de los tres ficheros `Autofirma.pkgproj`, siguiendo el mismo patrón que el `postinstall` existente.

## Pruebas

Verificado el diagnóstico en un equipo afectado (macOS Tahoe 26.5.1, Apple Silicon) con AutoFirma 1.8.x previo y el paquete 1.9.1 de la web oficial: el bundle fusionado contiene binarios de 2024 ajenos al recibo del paquete y la firma no valida. Eliminando el bundle antiguo antes de la instalación, la firma del bundle resultante valida correctamente.