### PR TITLE
Usar SecureRandom para seriales de certificado y nombres de script

### DIFF
--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/restoreconfig/CertUtil.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/restoreconfig/CertUtil.java
@@ -36,7 +36,6 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Random;
 
 import org.spongycastle.asn1.ASN1EncodableVector;
 import org.spongycastle.asn1.ASN1Sequence;
@@ -163,7 +162,7 @@ final class CertUtil {
 		expirationDate.setTime(new Date().getTime()+(long)10*365*24*3600*1000);
 		final X509v3CertificateBuilder generator = new JcaX509v3CertificateBuilder(
 			new X500Name("CN=" + commonName), //$NON-NLS-1$
-			BigInteger.valueOf(new Random().nextInt()),
+			BigInteger.valueOf(new SecureRandom().nextInt()),
     		new Date(),
     		expirationDate,
     		new X500Name("CN=" + commonName), //$NON-NLS-1$
@@ -244,7 +243,7 @@ final class CertUtil {
 
 			final X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
 				issuerDN,
-				BigInteger.valueOf(new Random().nextInt()),
+				BigInteger.valueOf(new SecureRandom().nextInt()),
 				new Date(),
 	    		expirationDate,
 	    		new X500Name("CN="+cn), //$NON-NLS-1$

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/restoreconfig/RestoreConfigFirefox.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/restoreconfig/RestoreConfigFirefox.java
@@ -23,11 +23,11 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStoreException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -195,7 +195,7 @@ final class RestoreConfigFirefox {
 			uninstall.append("\n"); //$NON-NLS-1$
 
 			// Obtenemos la ruta de los scripts
-			final Random r = new Random();
+			final SecureRandom r = new SecureRandom();
 			path = new File(targetDir,  LINUX_SCRIPT_NAME + r.nextInt() + ".sh").getAbsolutePath(); //$NON-NLS-1$
 			uninstallPath = new File(targetDir, LINUX_UNINSTALLSCRIPT_NAME + r.nextInt() + ".sh").getAbsolutePath(); //$NON-NLS-1$
 			final File installScript = new File(path);
@@ -518,7 +518,7 @@ final class RestoreConfigFirefox {
 				uninstall.append(command[7] + ' ');
 			}
 
-			final Random r = new Random();
+			final SecureRandom r = new SecureRandom();
 			path = new File(workingDir, LINUX_SCRIPT_NAME + r.nextInt() + ".sh").getAbsolutePath(); //$NON-NLS-1$
 			uninstallPath = new File(workingDir, LINUX_UNINSTALLSCRIPT_NAME + r.nextInt() + ".sh").getAbsolutePath(); //$NON-NLS-1$
 

--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/CertUtil.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/CertUtil.java
@@ -27,7 +27,6 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Random;
 
 import org.spongycastle.asn1.ASN1EncodableVector;
 import org.spongycastle.asn1.ASN1Sequence;
@@ -204,7 +203,7 @@ final class CertUtil {
 		expirationDate.setTime(new Date().getTime()+(long)10*365*24*3600*1000);
 		final X509v3CertificateBuilder generator = new JcaX509v3CertificateBuilder(
 			new X500Name(subjectPrincipal),
-			BigInteger.valueOf(new Random().nextInt()),
+			BigInteger.valueOf(new SecureRandom().nextInt()),
     		new Date(),
     		expirationDate,
     		new X500Name(subjectPrincipal),
@@ -302,7 +301,7 @@ final class CertUtil {
 
 			final X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
 				issuerDN,
-				BigInteger.valueOf(new Random().nextInt()),
+				BigInteger.valueOf(new SecureRandom().nextInt()),
 				new Date(),
 	    		expirationDate,
 	    		new X500Name("CN=" + commonName), //$NON-NLS-1$


### PR DESCRIPTION
## Resumen

Sustituye `java.util.Random` por `java.security.SecureRandom` en todas las ubicaciones donde se generan seriales de certificados y nombres de ficheros temporales.

## Problema

`java.util.Random` no es criptograficamente seguro. Su semilla por defecto deriva del tiempo del sistema, lo que permite predecir los valores generados si se conoce o estima el momento de ejecucion.

Esto afecta a:

- **Seriales de certificados autofirmados** en `CertUtil` (configurator y restoreconfig): un atacante que prediga la semilla podria predecir los numeros de serie, facilitando colisiones intencionadas o suplantacion.
- **Nombres de scripts temporales** en `RestoreConfigFirefox`: los nombres de ficheros `.sh` generados con `Random` son predecibles, lo que podria permitir ataques de path prediction en sistemas multiusuario.

## Cambios

| Fichero | Cambio |
|---|---|
| `afirma-ui-simple-configurator/.../configurator/CertUtil.java` | 2x `new Random().nextInt()` -> `new SecureRandom().nextInt()` |
| `afirma-simple/.../restoreconfig/CertUtil.java` | 2x `new Random().nextInt()` -> `new SecureRandom().nextInt()` |
| `afirma-simple/.../restoreconfig/RestoreConfigFirefox.java` | 2x `new Random()` -> `new SecureRandom()` |

Tambien se ha eliminado el import `java.util.Random` donde ya no se usa y se ha anadido `import java.security.SecureRandom` en `RestoreConfigFirefox`.

## Notas

- `SecureRandom.nextInt()` tiene la misma firma que `Random.nextInt()`, por lo que no hay cambios en la API.
- Los modulos `afirma-ui-simple-configurator` y `afirma-simple` ya importaban `SecureRandom` en `CertUtil.java` (se usaba para `KeyPairGenerator.initialize()`).
- No se puede compilar localmente sin Maven instalado, pero el cambio es una sustitucion directa de tipo que mantiene la compatibilidad de API.

Closes #533