### PR TITLE
Prohibir declaracion DOCTYPE en SecureXmlBuilder (billion laughs)

### DIFF
--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/SecureXmlBuilder.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/SecureXmlBuilder.java
@@ -54,6 +54,15 @@ public class SecureXmlBuilder {
 				}
 			}
 
+			// Prohibimos la declaracion DOCTYPE para prevenir ataques de expansion
+			// de entidades internas (billion laughs / XML bomb)
+			try {
+				SECURE_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); //$NON-NLS-1$
+			}
+			catch (final Exception e) {
+				Logger.getLogger("es.gob.afirma").log(Level.WARNING, "No se ha podido prohibir la declaracion DOCTYPE en la factoria XML: " + e); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+
 			SECURE_BUILDER_FACTORY.setValidating(false);
 			SECURE_BUILDER_FACTORY.setNamespaceAware(true);
 		}
@@ -89,6 +98,16 @@ public class SecureXmlBuilder {
 				Logger.getLogger("es.gob.afirma").log( //$NON-NLS-1$
 						Level.FINE,
 						"No se ha podido establecer una caracteristica de seguridad en la factoria SAX XML: " + e); //$NON-NLS-1$
+			}
+
+			// Prohibimos la declaracion DOCTYPE en SAX tambien
+			try {
+				SAX_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); //$NON-NLS-1$
+			}
+			catch (final Exception e) {
+				Logger.getLogger("es.gob.afirma").log( //$NON-NLS-1$
+						Level.FINE,
+						"No se ha podido prohibir la declaracion DOCTYPE en la factoria SAX XML: " + e); //$NON-NLS-1$
 			}
 
 			SAX_FACTORY.setValidating(false);


### PR DESCRIPTION
## Resumen

Activa `http://apache.org/xml/features/disallow-doctype-decl` en `DocumentBuilderFactory` y `SAXParserFactory` de `SecureXmlBuilder`.

## Problema

`SecureXmlBuilder` configura `FEATURE_SECURE_PROCESSING`, bloquea DTD/schema/stylesheet externos y desactiva entidades externas en SAX. Pero no prohibe la declaracion DOCTYPE, por lo que los ataques de expansion de entidades internas (billion laughs / XML bomb) siguen siendo posibles:

```xml
<!DOCTYPE bomb [
  <!ENTITY a "xxx...xxx">
  <!ENTITY b "&a;&a;&a;...&a;">
  <!ENTITY c "&b;&b;&b;...&b;">
]>
<bomb>&c;</bomb>
```

Un XML malicioso (por ejemplo, un XML firmado manipulado) podria causar denial-of-service por consumo excesivo de memoria.

## Cambios

Un solo fichero: `afirma-core/src/main/java/es/gob/afirma/core/misc/SecureXmlBuilder.java`

- `getSecureDocumentBuilder()`: anade `disallow-doctype-decl` con try/catch y log WARNING
- `getSecureSAXParser()`: anade `disallow-doctype-decl` con try/catch y log FINE

## Verificacion

Ningun flujo activo parsea documentos con DOCTYPE a traves de `SecureXmlBuilder`:
- XML signatures, OOXML (.rels), ODF (manifest.xml), XMP, facturae, TriphaseData, plist, Office content types: ninguno usa DOCTYPE interno
- JavaHelp parsea sus XML con su propio `DocumentBuilderFactory`, no con `SecureXmlBuilder`
- El unico test que usaba un XML con DTD interno (`sample-internal-dtd.xml`) esta comentado en `TestXAdES.java:129`

Closes #539