### PR TITLE
Usar TLS en lugar de SSL en SSLContext

### DIFF
--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/http/DataDownloader.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/http/DataDownloader.java
@@ -78,7 +78,7 @@ public final class DataDownloader {
 				sslConfig = new SSLConfig();
 				sslConfig.setHostnameVerifier(SslSecurityManager.DUMMY_HOSTNAME_VERIFIER);
 				try {
-					final SSLContext sslContext = SSLContext.getInstance("SSL"); //$NON-NLS-1$
+					final SSLContext sslContext = SSLContext.getInstance("TLS"); //$NON-NLS-1$
 					sslContext.init(null, SslSecurityManager.DUMMY_TRUST_MANAGER, new SecureRandom());
 					sslConfig.setSSLSocketFactory(sslContext.getSocketFactory());
 				}

--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/http/SslSecurityManager.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/http/SslSecurityManager.java
@@ -64,7 +64,7 @@ public final class SslSecurityManager {
 	private static final String KEYSTORE_TYPE = "javax.net.ssl.keyStoreType"; //$NON-NLS-1$
 	private static final String KEYSTORE_DEFAULT_TYPE = "JKS"; //$NON-NLS-1$
 
-	private static final String SSL_CONTEXT = "SSL";//$NON-NLS-1$
+	private static final String SSL_CONTEXT = "TLS";//$NON-NLS-1$
 
 	private static final HostnameVerifier DEFAULT_HOSTNAME_VERIFIER = HttpsURLConnection.getDefaultHostnameVerifier();
 	private static final SSLSocketFactory DEFAULT_SSL_SOCKET_FACTORY = HttpsURLConnection.getDefaultSSLSocketFactory();
@@ -274,7 +274,7 @@ public final class SslSecurityManager {
 
 		LOGGER.info("Se configura el almacen de confianza de Autofirma"); //$NON-NLS-1$
 
-		final SSLContext sslContext = SSLContext.getInstance("SSL"); //$NON-NLS-1$
+		final SSLContext sslContext = SSLContext.getInstance(SSL_CONTEXT); //$NON-NLS-1$
 		sslContext.init(null, new TrustManager[] { trustManager }, secureRandom);
 
 		HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());


### PR DESCRIPTION
## Resumen

Cambia `SSLContext.getInstance("SSL")` por `"TLS"` en todas las ubicaciones del codigo.

## Problema

El protocolo SSL esta obsoleto y presenta vulnerabilidades conocidas (POODLE, BEAST). Usar `"SSL"` como algoritmo de contexto permite la negociacion de protocolos inseguros, exponiendo las conexiones HTTPS a ataques de degradacion (downgrade).

## Cambios

| Fichero | Cambio |
|---|---|
| `SslSecurityManager.java:67` | Constante `SSL_CONTEXT = "SSL"` -> `"TLS"` |
| `SslSecurityManager.java:277` | `getInstance("SSL")` -> `getInstance(SSL_CONTEXT)` (usa la constante) |
| `DataDownloader.java:81` | `getInstance("SSL")` -> `getInstance("TLS")` |

## Notas

- `"TLS"` permite a la JVM negociar la version mas alta disponible (TLS 1.2 en Java 8, TLS 1.3 en Java 11+). Fijar `"TLSv1.2"` como hace el PR #314 impide usar TLS 1.3 cuando esta disponible.
- Esto supera y deberia cerrar el PR #314 abierto desde marzo 2023.

Closes #532