### PR TITLE
Validar IP y sessionId en WebSocket V1

### DIFF
--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/AfirmaWebSocketServer.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/AfirmaWebSocketServer.java
@@ -9,6 +9,7 @@
 
 package es.gob.afirma.standalone.protocol;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.logging.Level;
@@ -19,7 +20,9 @@ import org.java_websocket.framing.CloseFrame;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
 
+import es.gob.afirma.core.ErrorCode;
 import es.gob.afirma.core.misc.protocol.ProtocolVersion;
+import es.gob.afirma.standalone.SimpleErrorCode;
 import es.gob.afirma.standalone.protocol.AfirmaWebSocketServerManager.BindingErrorListener;
 
 /**
@@ -35,6 +38,14 @@ public class AfirmaWebSocketServer extends WebSocketServer {
 
 	/** Respuesta que se debe enviar ante las peticiones de echo correctas. */
 	private static final String ECHO_OK_RESPONSE = "OK"; //$NON-NLS-1$
+
+	/** IP local. */
+	private static final String LOCALHOST_ADDRESS = "127.0.0.1"; //$NON-NLS-1$
+
+	/** Sufijo de las peticiones de eco. */
+	private static final String ECHO_REQUEST_SUFFIX = "@EOF"; //$NON-NLS-1$
+
+	private static final String IDSESSION_PARAM_PREFIX = "idsession="; //$NON-NLS-1$
 
 	/** Uno de los prefijos que puede presentar el mensaje de invocaci&oacute;n de una firma de lote. Versi&oacute;n 1. */
 	private static final String HEADER_BATCH_1 = "afirma://batch?"; //$NON-NLS-1$
@@ -138,6 +149,24 @@ public class AfirmaWebSocketServer extends WebSocketServer {
 	public void onMessage(final WebSocket ws, final String message) {
 		LOGGER.info("Recibimos una peticion en el socket del puerto: " + getAddress().getPort()); //$NON-NLS-1$
 
+		// Comprobamos que la peticion haya llegado del mismo equipo
+		final InetAddress remoteAddress = ws.getRemoteSocketAddress().getAddress();
+		if (remoteAddress == null || !isLocalAddress(remoteAddress)) {
+			LOGGER.warning("Peticion al socket desde IP externa o sin identificar: " + remoteAddress); //$NON-NLS-1$
+			final String errorResponse = ProtocolInvocationLauncherErrorManager.getErrorMessage(MIN_PROTOCOL_VERSION, SimpleErrorCode.Communication.EXTERNAL_REQUEST);
+			broadcast(errorResponse, Collections.singletonList(ws));
+			return;
+		}
+
+		// Si se proporciono un ID de sesion al crear el socket y el ID del
+		// mensaje enviado no coincide con el mismo, ignoraremos la peticion
+		if (this.sessionId != null && !this.sessionId.equals(getSessionId(message))) {
+			LOGGER.warning("La peticion no incluia el id de sesion correcto"); //$NON-NLS-1$
+			final String errorResponse = ProtocolInvocationLauncherErrorManager.getErrorMessage(MIN_PROTOCOL_VERSION, SimpleErrorCode.Request.INVALID_SESSION_ID);
+			broadcast(errorResponse, Collections.singletonList(ws));
+			return;
+		}
+
 		// Indicamos que el socket esta operativo y recibiendo peticiones
 		// para evitar el cierre de seguridad
 		markAsWorking();
@@ -175,6 +204,39 @@ public class AfirmaWebSocketServer extends WebSocketServer {
 		this.bindingErrorListener = bindingErrorListener;
 	}
 
+
+	/**
+	 * Comprueba que una direcci&oacute;n de red sea la 127.0.0.1.
+	 * @param address Direcci&oacute;n de red.
+	 * @return {@code true} si la direccion de red es la 127.0.0.1, {@code false} en caso contrario.
+	 */
+	protected static boolean isLocalAddress(final InetAddress address) {
+		return address != null && LOCALHOST_ADDRESS.equals(address.getHostAddress());
+	}
+
+	/**
+	 * Devuelve el valor del par&aacute;metro "idsession" del mensaje.
+	 * @param message Mensaje.
+	 * @return Par&aacute;metro "idsession" o {@code null} si no se encontr&oacute;.
+	 */
+	protected static String getSessionId(final String message) {
+		String id = null;
+		final int idx = message.indexOf(IDSESSION_PARAM_PREFIX);
+		if (idx > -1) {
+			final int startIdx = idx + IDSESSION_PARAM_PREFIX.length();
+			final int endIdx = message.indexOf("&", startIdx); //$NON-NLS-1$
+			if (endIdx > -1) {
+				id = message.substring(startIdx, endIdx);
+			}
+			else {
+				id = message.substring(startIdx);
+				if (id.endsWith(ECHO_REQUEST_SUFFIX)) {
+					id = id.substring(0, id.length() - ECHO_REQUEST_SUFFIX.length());
+				}
+			}
+		}
+		return id;
+	}
 
 	/**
 	 * Hilo para el cierre del websocket pasado un cierto tiempo.

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/AfirmaWebSocketServerV4Sup.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/protocol/AfirmaWebSocketServerV4Sup.java
@@ -27,16 +27,8 @@ public final class AfirmaWebSocketServerV4Sup extends AfirmaWebSocketServer {
 	/** Prefijo de las peticiones de eco. */
 	private static final String ECHO_REQUEST_PREFIX = "echo="; //$NON-NLS-1$
 
-	/** Sufijo de las peticiones de eco. */
-	private static final String ECHO_REQUEST_SUFFIX = "@EOF"; //$NON-NLS-1$
-
-	private static final String IDSESSION_PARAM_PREFIX = "idsession="; //$NON-NLS-1$
-
 	/** Respuesta que se debe enviar ante las peticiones de echo correctas. */
 	private static final String ECHO_OK_RESPONSE = "OK"; //$NON-NLS-1$
-
-	/** IP local. */
-	private static final String LOCALHOST_ADDRESS = "127.0.0.1"; //$NON-NLS-1$
 
 	/** Uno de los prefijos que puede presentar el mensaje de invocaci&oacute;n de una firma de lote. Versi&oacute;n 1. */
 	private static final String HEADER_BATCH_1 = "afirma://batch?"; //$NON-NLS-1$
@@ -114,15 +106,6 @@ public final class AfirmaWebSocketServerV4Sup extends AfirmaWebSocketServer {
 	}
 
 	/**
-	 * Comprueba que una direcci&oacute;n de red sea la 127.0.0.1.
-	 * @param address Direcci&oacute;n de red.
-	 * @return {@code true} si la direccion de red es la 127.0.0.1, {@code false} en caso contrario.
-	 */
-	private static boolean isLocalAddress(final InetAddress address) {
-		return address != null && LOCALHOST_ADDRESS.equals(address.getHostAddress());
-	}
-
-	/**
 	 * Indica si el m&eacute;todo debe de tratar la operaci&oacute;n como as&iacute;ncrona o no.
 	 * @param isAsyncOp {@code true} si se desea que se trate la operacion como as&iacute;ncrona.
 	 */
@@ -130,28 +113,4 @@ public final class AfirmaWebSocketServerV4Sup extends AfirmaWebSocketServer {
 		this.isAsyncOperation = isAsyncOp;
 	}
 
-	/**
-	 * Devuelve el valor del par&aacute;metro "idsession" del mensaje.
-	 * @param message Mensaje.
-	 * @return Par&aacute;metro "idsession" o {@code null} si no se encontr&oacute;.
-	 */
-	private static String getSessionId(final String message) {
-		String id = null;
-		final int idx = message.indexOf(IDSESSION_PARAM_PREFIX);
-		if (idx > -1) {
-			final int startIdx = idx + IDSESSION_PARAM_PREFIX.length();
-			final int endIdx = message.indexOf("&", startIdx); //$NON-NLS-1$
-			if (endIdx > -1) {
-				id = message.substring(startIdx, endIdx);
-			}
-			else {
-				id = message.substring(startIdx);
-				if (id.endsWith(ECHO_REQUEST_SUFFIX)) {
-					id = id.substring(0, id.length() - ECHO_REQUEST_SUFFIX.length());
-				}
-			}
-		}
-
-		return id;
-	}
 }


### PR DESCRIPTION
## Resumen

Anade validacion de IP local (127.0.0.1) y sessionId en `onMessage` de `AfirmaWebSocketServer` (WebSocket V1), igual que `AfirmaWebSocketServerV4Sup` ya implementa para V4.

## Problema

El servidor WebSocket V1 (`AfirmaWebSocketServer.java`) aceptaba cualquier conexion entrante sin verificar:
- Que la peticion viniera de `127.0.0.1`
- Que el `idsession` del mensaje coincidiera con el de la sesion

Cualquier actor en la red local (o remota si el puerto era accesible) podia invocar operaciones de firma, firma por lotes y guardado de archivos sin autenticacion.

La version V4 (`AfirmaWebSocketServerV4Sup`) ya implementaba ambas validaciones, pero la V1 seguia activa para `ProtocolVersion.VERSION_0`.

## Cambios

| Fichero | Cambio |
|---|---|
| `AfirmaWebSocketServer.java` | Anade guards de IP y sessionId en `onMessage`; anade `isLocalAddress` y `getSessionId` como protected static |
| `AfirmaWebSocketServerV4Sup.java` | Elimina `isLocalAddress`, `getSessionId`, `LOCALHOST_ADDRESS`, `IDSESSION_PARAM_PREFIX`, `ECHO_REQUEST_SUFFIX` (duplicados, ahora en la clase base) |

## Notas

- `isLocalAddress` y `getSessionId` se mueven de V4 (private) a V1 (protected static) para eliminar la duplicacion. V4 las hereda sin cambios de comportamiento.
- Los mensajes de error usan `ProtocolInvocationLauncherErrorManager.getErrorMessage` con `MIN_PROTOCOL_VERSION` (VERSION_0), igual que V4 usa su protocolo correspondiente.

Closes #530