### PR TITLE
Advertir en logs cuando se deshabilitan comprobaciones SSL

### DIFF
--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/http/DataDownloader.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/http/DataDownloader.java
@@ -75,6 +75,7 @@ public final class DataDownloader {
 
 			SSLConfig sslConfig = null;
 			if (ignoreSSLSecurity) {
+				LOGGER.warning("Se deshabilitan las comprobaciones SSL para la descarga de: " + dataSource); //$NON-NLS-1$
 				sslConfig = new SSLConfig();
 				sslConfig.setHostnameVerifier(SslSecurityManager.DUMMY_HOSTNAME_VERIFIER);
 				try {

--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/http/SslSecurityManager.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/http/SslSecurityManager.java
@@ -83,6 +83,8 @@ public final class SslSecurityManager {
 	 * @throws GeneralSecurityException Si hay problemas al desactivar el uso de almacen de claves. */
 	public static void disableSslChecks(final HttpsURLConnection conn) throws GeneralSecurityException {
 
+		LOGGER.warning("Se deshabilitan las comprobaciones SSL para la conexion: " + conn.getURL()); //$NON-NLS-1$
+
 		final SSLContext sc = SSLContext.getInstance(SSL_CONTEXT);
 		sc.init(null, DUMMY_TRUST_MANAGER, secureRandom);
 
@@ -94,6 +96,7 @@ public final class SslSecurityManager {
 	 * cualquier certificado.
 	 * @throws GeneralSecurityException Si hay problemas al desactivar el uso de almacen de claves. */
 	public static void disableSslChecks() throws GeneralSecurityException {
+		LOGGER.warning("Se deshabilitan las comprobaciones SSL globalmente"); //$NON-NLS-1$
 		setTrustManagerAndKeyManager(
 			DUMMY_TRUST_MANAGER,
 			DUMMY_HOSTNAME_VERIFIER,

--- a/afirma-crypto-core-pkcs7-tsp/src/main/java/es/gob/afirma/signers/tsp/pkcs7/CMSTimestamper.java
+++ b/afirma-crypto-core-pkcs7-tsp/src/main/java/es/gob/afirma/signers/tsp/pkcs7/CMSTimestamper.java
@@ -447,6 +447,7 @@ public final class CMSTimestamper {
 			}
     	}
     	else {
+    		LOGGER.warning("No se ha configurado almacen de confianza para el sello de tiempo; se aceptara cualquier certificado SSL"); //$NON-NLS-1$
     		trustManagers = new TrustManager[] {
     			new X509TrustManager() {
 					@Override


### PR DESCRIPTION
## Resumen

Anade log WARNING en cada punto donde se deshabilitan las comprobaciones SSL, dejando rastro auditable.

## Problema

`DUMMY_TRUST_MANAGER` y `DUMMY_HOSTNAME_VERIFIER` aceptan cualquier certificado SSL sin verificar. Esto es necesario para flujos legitimos (descargas con `ignoreSSLSecurity`, sellos de tiempo sin trustStore configurado), pero lo hacian de forma silenciosa, sin dejar rastro en logs.

## Cambios

| Fichero | Cambio |
|---|---|
| `SslSecurityManager.java` | WARNING en `disableSslChecks(conn)` y `disableSslChecks()` |
| `DataDownloader.java` | WARNING cuando `ignoreSSLSecurity=true` |
| `CMSTimestamper.java` | WARNING cuando no hay trustStore configurado |

5 lineas anadidas. No se elimina `DUMMY_TRUST_MANAGER` ni se cambia la logica existente.

Closes #531