### PR TITLE
Resolver host en validateURL para prevenir SSRF

### DIFF
--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/protocol/UrlParameters.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/protocol/UrlParameters.java
@@ -11,8 +11,10 @@ package es.gob.afirma.core.misc.protocol;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
@@ -422,7 +424,7 @@ public abstract class UrlParameters {
 	 * @param url URL que se desea validar.
 	 * @return URL formada y validada.
 	 * @throws IllegalArgumentException Cuando ocurre alg&uacute;n problema al validar la URL.
-	 * @throws LocalAccessRequestException Cuando la URL usa los dominios localhost o 127.0.0.1.
+	 * @throws LocalAccessRequestException Cuando la URL apunta a una direccion local.
 	 */
 	protected static URL validateURL(final String url) throws IllegalArgumentException, LocalAccessRequestException {
 
@@ -442,10 +444,28 @@ public abstract class UrlParameters {
 				"El protocolo de la URL proporcionada para el servlet no esta soportado: " + servletUrl.getProtocol() //$NON-NLS-1$
 			);
 		}
-		// Comprobamos que la URL sea una llamada al servlet y que no sea local
-		if ("localhost".equals(servletUrl.getHost()) || "127.0.0.1".equals(servletUrl.getHost())) { //$NON-NLS-1$ //$NON-NLS-2$
+		// Comprobamos que la URL no apunte a una direccion local
+		final String host = servletUrl.getHost();
+		if ("localhost".equals(host) || "127.0.0.1".equals(host)) { //$NON-NLS-1$ //$NON-NLS-2$
 			throw new LocalAccessRequestException(
 				"El host de la URL proporcionada para el Servlet es local" //$NON-NLS-1$
+			);
+		}
+		// Resolvemos el host para comprobar que no apunta a una direccion local
+		// Evita bypasses via DNS rebinding, IP en decimal/octal/hex, etc.
+		try {
+			final InetAddress[] addresses = InetAddress.getAllByName(host);
+			for (final InetAddress addr : addresses) {
+				if (addr.isLoopbackAddress() || addr.isAnyLocalAddress()) {
+					throw new LocalAccessRequestException(
+						"El host de la URL proporcionada para el Servlet resuelve a una direccion local: " + addr //$NON-NLS-1$
+					);
+				}
+			}
+		}
+		catch (final UnknownHostException e) {
+			throw new IllegalArgumentException(
+				"No se ha podido resolver el host de la URL: " + host //$NON-NLS-1$
 			);
 		}
 		// El servlet no puede recibir parametros


### PR DESCRIPTION
## Resumen

`validateURL` solo comprobaba string equality con `localhost` y `127.0.0.1`. Ahora resuelve el host via DNS y comprueba si la IP resultante es local.

## Problema

Un atacante puede bypassear la comprobacion con:
- Dominios que resuelven a loopback (DNS rebinding)
- IP en decimal (`2130706433`), octal (`0177.0.0.1`), hex (`0x7f000001`)
- IPv6 loopback (`::1`)
- `0.0.0.0` (wildcard)

## Cambios

Un solo fichero: `afirma-core/src/main/java/es/gob/afirma/core/misc/protocol/UrlParameters.java`

Despues de la comprobacion string existente, se anade:
- `InetAddress.getAllByName(host)` para resolver el host
- `isLoopbackAddress()` y `isAnyLocalAddress()` en cada direccion
- `UnknownHostException` se traduce a `IllegalArgumentException`

La comprobacion string original se mantiene como fast-path (evita DNS lookup para casos obvios).

## Notas

- `validateURL` es el unico punto de validacion, llamado desde 6 sitios (UrlParametersToSign, UrlParametersToSignAndSave, UrlParametersForBatch, UrlParametersToSave, UrlParametersToSelectCert, UrlParameters).
- TOCTOU: la resolucion DNS puede cambiar entre validateURL y la peticion HTTP real (DNS rebinding). Esto es una limitacion inherente al modelo de validacion previa. Una defensa completa requeriria validar la IP del socket ya conectado.

Closes #521