### PR TITLE
Corregir la errata «Recomends» en el control del paquete Debian (#302)

### DIFF
--- a/afirma-simple-installer/linux/instalador_deb/src/DEBIAN/control
+++ b/afirma-simple-installer/linux/instalador_deb/src/DEBIAN/control
@@ -3,7 +3,7 @@ Architecture: all
 Section: utils
 Priority: optional
 Depends: libnss3-tools
-Recomends: openjdk-17-jre 
+Recommends: openjdk-17-jre
 Description: Autofirma - Cliente @firma
 Version: 1.9.0
 License: GPL-2+ | EUPL-1.1


### PR DESCRIPTION
El campo del `control` del paquete Debian está escrito con una sola eme:

```
Depends: libnss3-tools
Recomends: openjdk-17-jre
```

`Recomends` no es un campo válido de Debian, así que `dpkg` lo arrastra como campo de usuario y no actúa. **El JRE no queda declarado por ninguna vía**, ni siquiera con `apt install --install-recommends`. Medido sobre el `.deb` 1.9 que se descarga de `firmaelectronica.gob.es`:

```
$ apt-cache depends autofirma
autofirma
  Depende: libnss3-tools
```

Es el issue #302, y el efecto es peor de lo que allí se describe: sin Java, el `postinst` encadena ocho órdenes fallidas y la instalación termina igualmente en `install ok installed` con código 0, sin generar los certificados y sin dejar ningún mensaje. Instalar Java después no repara nada, porque el `postinst` ya corrió y nada vuelve a lanzarlo.

Esta PR se limita a la errata, para que sea trivial de revisar.

**Sugerencia aparte, que dejo a vuestro criterio y no incluyo aquí:** dado que sin JRE el paquete no funciona en absoluto, `Depends` sería más apropiado que `Recommends`. Y conviene nombrar una versión concreta antes del virtual, porque `java-runtime` a secas tiene varios proveedores y en Ubuntu 24.04 `apt` resuelve a `openjdk-25`, con el que AutoFirma no está probado:

```
Depends: libnss3-tools, openjdk-17-jre | openjdk-21-jre | java-runtime
```

Si preferís esa forma, la cambio en esta misma rama.