### PR TITLE
Instalar la CA del socket en todos los perfiles de Mozilla, no solo en el primero

### DIFF
--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorFirefoxLinux.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorFirefoxLinux.java
@@ -39,6 +39,19 @@ final class ConfiguratorFirefoxLinux {
 
 	private static final String PROFILES_INI_RELATIVE_PATH = ".mozilla/firefox/profiles.ini";//$NON-NLS-1$
 	private static final String PROFILES_INI_RELATIVE_PATH_UBUNTU_22 = "snap/firefox/common/.mozilla/firefox/profiles.ini"; //$NON-NLS-1$
+	// Directorio de Firefox 147 y superiores
+	private static final String PROFILES_INI_RELATIVE_PATH_XDG = ".config/mozilla/firefox/profiles.ini"; //$NON-NLS-1$
+
+	/** Rutas relativas al directorio del usuario en las que puede encontrarse un
+	 * fichero <i>profiles.ini</i> de Mozilla. Se comprueban <b>todas</b>, no solo
+	 * la primera que exista: en un mismo sistema pueden convivir la
+	 * instalaci&oacute;n Snap y la nativa, cada una con sus propios perfiles, y el
+	 * certificado de CA debe quedar instalado en los de las dos. */
+	private static final String[] PROFILES_INI_RELATIVE_PATHS = new String[] {
+			PROFILES_INI_RELATIVE_PATH_UBUNTU_22,
+			PROFILES_INI_RELATIVE_PATH_XDG,
+			PROFILES_INI_RELATIVE_PATH
+	};
 
 	private static final String NSS_CHROME_PATH = "/.pki/nssdb"; //$NON-NLS-1$
 	private static final String NSS_CHROMIUM_PATH = "/snap/chromium/current/.pki/nssdb"; //$NON-NLS-1$
@@ -348,12 +361,9 @@ final class ConfiguratorFirefoxLinux {
 		final List<File> profilesIniFiles = new ArrayList<>();
 		for (final String userDir : userDirs){
 
-			File mozillaPath = new File(userDir, PROFILES_INI_RELATIVE_PATH_UBUNTU_22);
-			if (mozillaPath.isFile()) {
-				profilesIniFiles.add(mozillaPath);
-			} else {
-				mozillaPath = new File(userDir, PROFILES_INI_RELATIVE_PATH);
-				if (mozillaPath.isFile()){
+			for (final String relativePath : PROFILES_INI_RELATIVE_PATHS) {
+				final File mozillaPath = new File(userDir, relativePath);
+				if (mozillaPath.isFile()) {
 					profilesIniFiles.add(mozillaPath);
 				}
 			}


### PR DESCRIPTION
`ConfiguratorFirefoxLinux.getMozillaProfilesIniPaths()` recorre dos rutas con un `if/else` **excluyente**: si existe el `profiles.ini` del Snap, no se mira ninguna otra. Y le falta la ruta XDG `~/.config/mozilla/firefox/`, que es donde guardan los perfiles Firefox 147 y superiores.

En un sistema donde conviven la instalación Snap y la nativa —lo habitual en Ubuntu 24.04 con el paquete de `packages.mozilla.org` instalado— el certificado de CA acaba en el perfil del Snap, y **el navegador que la persona abre se queda sin él**. El configurador no registra ningún error: la instalación se declara correcta y la firma falla después, sin síntoma que seguir.

## Esto no pide una función nueva, pide terminar una empezada

`MozillaKeyStoreUtilities.getProfilesIniPath()`, en este mismo repositorio, **ya conoce la ruta XDG**, y lleva el motivo escrito al lado:

```java
// Directorio de Firefox 147 y superiores
if (new File(Platform.getUserHome() + "/.config/mozilla/firefox/profiles.ini").isFile()) {
    return Platform.getUserHome() + "/.config/mozilla/firefox/profiles.ini";
}
```

Hay tres implementaciones independientes de la misma búsqueda y no se comportan igual:

| Clase | Snap | `.config/mozilla` | `~/.mozilla` |
|---|---|---|---|
| `MozillaKeyStoreUtilities` | sí | **sí** | sí |
| `RestoreConfigFirefox` | sí | no | sí |
| `ConfiguratorFirefoxLinux` | sí | **no** | sí |

Esta PR alinea la tercera, reutilizando vuestro propio comentario.

## Por qué recorrer todas y no añadir una rama más

Añadir un `else if` no arregla el caso real: con el Snap instalado, la nueva rama nunca se evalúa. Las tres rutas pasan a un array que se recorre entero, así que se configuran los perfiles de todas las instalaciones que existan.

## Comprobado con sus dos salidas

Sobre un usuario con los tres perfiles a la vez, ejecutando el configurador con el jar sin parchear y con el parcheado, en la misma máquina y en la misma tanda. Se mira a qué perfiles manda instalar la CA el `script.sh` que genera:

```
════════ sin parche ════════        ════════ con parche ════════
  snap     SÍ configurado             snap     SÍ configurado
  xdg      no configurado             xdg      SÍ configurado
  legacy   no configurado             legacy   SÍ configurado
```

Y en una máquina real, tras aplicarlo: el perfil que Firefox usa de verdad pasa de 0 certificados a tener la CA con la **misma huella SHA-256** que la del disco, y la hoja del socket valida contra ella (verificado con `-no-CAstore`, porque OpenSSL 3.x lee `/etc/ssl/certs` por defecto y sin esa opción la comprobación sale `OK` siempre).

Con este cambio, junto con el registro del esquema, hemos conseguido una firma real con certificado FNMT en `valide.redsara.es` sobre Ubuntu 24.04 arm64 con el Firefox nativo de Mozilla.