### PR TITLE
Encontrar NSS en arquitecturas distintas de x86 (arm64, riscv64, ppc64el…)

### DIFF
--- a/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
+++ b/afirma-keystores-mozilla/src/main/java/es/gob/afirma/keystores/mozilla/MozillaKeyStoreUtilitiesUnix.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -42,6 +43,33 @@ final class MozillaKeyStoreUtilitiesUnix {
 		// No instanciable
 	}
 
+	/** Busca los directorios <i>multiarch</i> de Debian y derivadas
+	 * (<code>/usr/lib/&lt;triplete&gt;</code>) en los que se encuentre NSS.
+	 * Solo devuelve aquellos en los que <code>libsoftokn3.so</code> exista
+	 * realmente, para no ensuciar la lista de rutas a comprobar.
+	 * @return Rutas encontradas, en orden alfab&eacute;tico. */
+	private static List<String> getMultiarchNssPaths() {
+		final List<String> paths = new ArrayList<>();
+		final File[] dirs = new File("/usr/lib").listFiles(); //$NON-NLS-1$
+		if (dirs == null) {
+			return paths;
+		}
+		Arrays.sort(dirs);
+		for (final File dir : dirs) {
+			if (!dir.isDirectory() || dir.getName().indexOf("-linux-") == -1) { //$NON-NLS-1$
+				continue;
+			}
+			final File nssSubDir = new File(dir, "nss"); //$NON-NLS-1$
+			if (new File(nssSubDir, SOFTOKN3_SO).isFile()) {
+				paths.add(nssSubDir.getAbsolutePath());
+			}
+			if (new File(dir, SOFTOKN3_SO).isFile()) {
+				paths.add(dir.getAbsolutePath());
+			}
+		}
+		return paths;
+	}
+
 	private static String[] getNssPaths() {
 		final List<String> nssPaths = new ArrayList<>();
 		final String javaArch = Platform.getJavaArch();
@@ -55,6 +83,14 @@ final class MozillaKeyStoreUtilitiesUnix {
 			nssPaths.add("/usr/lib/i386-linux-gnu/nss"); /* En algunos Ubuntu y Debian 32 */ //$NON-NLS-1$
 			nssPaths.add("/usr/lib/i386-linux-gnu"); //$NON-NLS-1$
 		}
+
+		// Resto de directorios "multiarch" de Debian y derivadas. Las dos ramas
+		// de arriba solo cubren x86, asi que en cualquier otra arquitectura NSS
+		// no se encuentra: en arm64 vive en "/usr/lib/aarch64-linux-gnu", y en
+		// armhf, riscv64, ppc64el o s390x en el triplete que corresponda.
+		// Se enumeran en lugar de escribirlos a mano para no repetir el mismo
+		// problema en la siguiente arquitectura que aparezca.
+		nssPaths.addAll(getMultiarchNssPaths());
 
 		nssPaths.add(systemLibDir + "/nss"); //$NON-NLS-1$
 		nssPaths.add(systemLibDir);


### PR DESCRIPTION
`MozillaKeyStoreUtilitiesUnix.getNssPaths()` solo añade rutas *multiarch* de Debian para x86:

```java
if ("64".equals(javaArch)) {
    nssPaths.add("/usr/lib/x86_64-linux-gnu/nss");
    nssPaths.add("/usr/lib/x86_64-linux-gnu");
}
else if("32".equals(javaArch)) {
    nssPaths.add("/usr/lib/i386-linux-gnu/nss");
    nssPaths.add("/usr/lib/i386-linux-gnu");
}
```

En cualquier otra arquitectura esas rutas no existen. En un Ubuntu 24.04 **arm64**, NSS vive en `/usr/lib/aarch64-linux-gnu` y AutoFirma termina en:

```
SEVERE: Error obteniendo el proveedor NSS: java.io.FileNotFoundException:
        No se ha podido determinar la localizacion de NSS en UNIX
```

## Por qué importa más de lo que parece

Sin proveedor NSS, el almacén de Firefox no llega a inicializarse:

```
WARNING: No se pudieron obtener los alias del almacen Mozilla / Firefox (unificado):
         java.lang.IllegalStateException: Se han pedido alias a un almacen no inicializado
WARNING: No hay certificados validos en el almacen
```

Y lo que la persona ve es **«No se han encontrado certificados válidos en el almacén. Inserte una tarjeta inteligente en el lector»**, teniendo su certificado correctamente instalado en el perfil de Firefox y visible con `certutil -L`. El mensaje no menciona NSS por ninguna parte, así que no hay forma de llegar a la causa desde lo que se ve en pantalla.

## El cambio

Se enumeran los directorios *multiarch* en lugar de escribirlos a mano, para no repetir el mismo problema en la siguiente arquitectura (armhf, riscv64, ppc64el, s390x…), y solo se añaden aquellos en los que `libsoftokn3.so` existe de verdad, para no ensuciar la lista de rutas a comprobar.

**Las rutas actuales se conservan intactas: el cambio suma, no sustituye.** El resto de `getNssPaths()` no se toca, y el filtrado final por `ElfParser.archMatches()` sigue descartando las bibliotecas de arquitectura incorrecta.

## Comprobado

Sobre Ubuntu 24.04 arm64 con `libnss3` del sistema, tras el cambio:

```
INFO: Directorio de bibliotecas NSS: /usr/lib/aarch64-linux-gnu
INFO: Configuracion de NSS para SunPKCS11: library=/usr/lib/aarch64-linux-gnu/libsoftokn3.so
INFO: Anadido proveedor PKCS#11 de NSS de Mozilla: SunPKCS11-NSSCrypto-AFirma
INFO: Almacen de claves cargado
INFO: Certificado seleccionado por el usuario
```

Y a continuación, una firma real con certificado de la FNMT en `valide.redsara.es`.