### PR TITLE
No fabricar el almacen NSS de un perfil que el navegador no ha abierto

### DIFF
--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorFirefoxLinux.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorFirefoxLinux.java
@@ -50,8 +50,37 @@ final class ConfiguratorFirefoxLinux {
 
 	private static final String CERTUTIL_RESOURCE = "/linux/certutil.linux.zip"; //$NON-NLS-1$
 
+	/** Ficheros que denotan un almac&eacute;n NSS ya inicializado, en sus dos formatos:
+	 * <i>sql</i> (<code>cert9.db</code>, <code>pkcs11.txt</code>) y el antiguo
+	 * <i>dbm</i> (<code>cert8.db</code>). */
+	private static final String[] NSS_KEYSTORE_FILES = new String[] {
+			"cert9.db", //$NON-NLS-1$
+			"pkcs11.txt", //$NON-NLS-1$
+			"cert8.db" //$NON-NLS-1$
+	};
+
 	private ConfiguratorFirefoxLinux() {
 		// No instanciable
+	}
+
+	/** Indica si un directorio contiene ya un almac&eacute;n NSS.
+	 * <p>
+	 * Hace falta porque <code>certutil</code> <b>crea</b> el almac&eacute;n indicado con
+	 * <code>-d</code> cuando no existe, tanto al a&ntilde;adir un certificado con
+	 * <code>-A</code> como al borrarlo con <code>-D</code>. Sobre un directorio sin
+	 * almac&eacute;n, los comandos que genera este configurador no rellenan nada: lo
+	 * fabrican.
+	 * </p>
+	 * @param dir Directorio del perfil o del almac&eacute;n.
+	 * @return <code>true</code> si el directorio ya tiene un almac&eacute;n NSS,
+	 *         <code>false</code> en caso contrario. */
+	private static boolean hasNssKeyStore(final File dir) {
+		for (final String keystoreFile : NSS_KEYSTORE_FILES) {
+			if (new File(dir, keystoreFile).isFile()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -92,6 +121,14 @@ final class ConfiguratorFirefoxLinux {
 
 				final String keystorePath = userDir + nssSubpath;
 				if (!new File(keystorePath).isDirectory()) {
+					continue;
+				}
+
+				// Si el directorio existe pero todavia no tiene almacen, certutil lo
+				// crearia. El almacen de un usuario lo tiene que crear su navegador.
+				if (!hasNssKeyStore(new File(keystorePath))) {
+					LOGGER.info("Se omite un directorio NSS sin almacen inicializado: " //$NON-NLS-1$
+							+ keystorePath);
 					continue;
 				}
 
@@ -239,6 +276,16 @@ final class ConfiguratorFirefoxLinux {
 
 		for (final File profileDir : profilesDir) {
 			if (!profileDir.isDirectory()) {
+				continue;
+			}
+
+			// profiles.ini declara perfiles que el navegador puede no haber abierto nunca,
+			// y esos no tienen almacen. Sobre ellos certutil no anadiria el certificado:
+			// crearia el almacen entero, y el navegador se encontraria despues un almacen
+			// que no ha hecho el.
+			if (!hasNssKeyStore(profileDir)) {
+				LOGGER.info("Se omite un perfil de Mozilla sin almacen NSS inicializado: " //$NON-NLS-1$
+						+ profileDir.getAbsolutePath());
 				continue;
 			}
 


### PR DESCRIPTION
`certutil` **crea** el almacén indicado con `-d` cuando no existe. Lo hace al
añadir un certificado con `-A` y, cosa menos evidente, **también al borrarlo con
`-D`**: sale con 255 y «could not find certificate», y aun así deja `cert9.db`,
`key4.db` y `pkcs11.txt` detrás.

Medido sobre `libnss3-tools` de Ubuntu 24.04, con sus controles:

```
-A (anadir)             rc=0    tras la orden: cert9.db key4.db pkcs11.txt
-L (listar)             rc=255  tras la orden: (ninguno)
-D (borrar por apodo)   rc=255  tras la orden: cert9.db key4.db pkcs11.txt
-K (listar claves)      rc=255  tras la orden: (ninguno)
```

## El problema

Los dos bucles que escriben los scripts recorren directorios que pueden no tener
almacén todavía:

- `createScriptsToSystemKeyStore` comprueba que `~/.pki/nssdb` sea un
  directorio, pero no que tenga almacén dentro. Un Chrome recién instalado deja
  el directorio creado y vacío.
- `writeScriptsToMozillaKeyStore` recorre lo que declara `profiles.ini`, y
  `profiles.ini` declara perfiles que el navegador no ha abierto nunca. Firefox
  crea dos en el primer arranque y solo abre uno; el otro queda declarado, a
  menudo con `Default=1`, y sin ningún fichero dentro.

Sobre esos directorios los comandos generados no rellenan el almacén: **lo
fabrican**. Y como el instalador Debian ejecuta `script.sh` desde el `postinst`,
o sea **como root**, el almacén nace propiedad de root dentro del directorio
personal de otro usuario.

Reproducido en un contenedor Ubuntu 24.04, con un perfil declarado y nunca
abierto y un `~/.pki/nssdb` vacío:

```
$ cat /usr/share/AutoFirma/script.sh
certutil -d sql:/home/u/.pki/nssdb -A -n "SocketAutoFirma" -i <CA> -t "TCP,TCP,TCP"
certutil -A -d /home/u/.config/mozilla/firefox/nuncaabierto.default -i <CA> -n "SocketAutoFirma" -t "C,,"

$ ls -l /home/u/.config/mozilla/firefox/nuncaabierto.default/
-rw------- 1 root root 28672 cert9.db
-rw------- 1 root root 36864 key4.db
-rw------- 1 root root   463 pkcs11.txt
```

A partir de ahí el navegador no puede escribir en un almacén que cree suyo, y
cualquier herramienta que pase después por ese perfil como el usuario falla al
abrirlo. El síntoma no menciona a AutoFirma por ninguna parte.

## El cambio

Una comprobación previa en los dos bucles: si el directorio no tiene ya un
almacén NSS —`cert9.db` o `pkcs11.txt` para el formato *sql*, `cert8.db` para el
antiguo— se omite y se registra en el log.

Un perfil sin almacén **no pierde nada**, porque hoy tampoco recibe un almacén
utilizable: recibe uno que su dueño no puede escribir.

De paso queda a la vista un detalle del propio método: `sqlDb` se decide por la
presencia de `pkcs11.txt`, que solo existe si el almacén existe, así que sobre un
perfil vacío la respuesta era siempre «formato antiguo» y NSS acababa creando uno
*sql* igualmente. Con la comprobación delante, ese caso ya no se alcanza.

## Alcance

Un solo fichero, sin cambiar ninguna firma pública ni ningún comportamiento
sobre perfiles que sí tienen almacén. El módulo compila con
`mvn -Denv=install -pl afirma-ui-simple-configurator -am`.