### PR TITLE
Elimina el código de Applet y Java Web Start del cliente de escritorio

### DIFF
--- a/afirma-core/src/main/java/es/gob/afirma/core/misc/Platform.java
+++ b/afirma-core/src/main/java/es/gob/afirma/core/misc/Platform.java
@@ -243,17 +243,6 @@ public final class Platform {
      * devolver&aacute; {@code null}. Copiado de com.sun.deploy.config.Config.
      * @return Directorio del entorno de ejecuci&oacute;n de Java. */
     private static String recoverJavaHome() {
-        String ret = null;
-        try {
-            ret = System.getProperty("jnlpx.home"); //$NON-NLS-1$
-        }
-        catch (final Exception e) {
-            LOGGER.warning("No se ha podido leer la variable 'jnlpx.home': " + e); //$NON-NLS-1$
-        }
-        if (ret != null) {
-            return ret.substring(0, ret.lastIndexOf(File.separator));
-        }
-
         try {
             return System.getProperty("java.home"); //$NON-NLS-1$
         }

--- a/afirma-keystores-jmulticard-ui/src/main/java/es/gob/afirma/keystores/jmulticard/ui/LanguageUtils.java
+++ b/afirma-keystores-jmulticard-ui/src/main/java/es/gob/afirma/keystores/jmulticard/ui/LanguageUtils.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.logging.Logger;
@@ -112,10 +111,6 @@ public class LanguageUtils {
 	
 	private static File getApplicationDirectory() {
 
-		if (isJnlpDeployment()) {
-			return getJNLPApplicationDirectory();
-		}
-
 		// Identificamos el directorio de instalacion
 		try {
 			return new File(
@@ -127,49 +122,6 @@ public class LanguageUtils {
 		}
 
 		return null;
-	}
-	
-	/**
-	 * Obtiene el directorio de aplicaci&oacute;n que corresponde cuando se
-	 * ejecuta la aplicaci&oacute;n mediante un despliegue es JNLP.
-	 * @return Directorio de aplicaci&oacute;n.
-	 */
-	private static File getJNLPApplicationDirectory() {
-		if (getOS() == OS.WINDOWS) {
-			final File appDir = getWindowsAlternativeAppDir();
-			if (appDir.isDirectory() || appDir.mkdirs()) {
-				return appDir;
-			}
-		}
-		else if (getOS() == OS.MACOSX) {
-			final File appDir = getMacOsXAlternativeAppDir();
-			if (appDir.isDirectory() || appDir.mkdirs()) {
-				return appDir;
-			}
-		}
-		return new File(System.getProperty("java.io.tmpdir")); //$NON-NLS-1$
-	}
-	
-	/**
-	 * Comprueba si estamos en un despliegue JNLP de la aplicaci&oacute;n.
-	 * @return {@code true} si estamos en un despliegue JNLP, {@code false}
-	 * en caso contrario.
-	 */
-	private static boolean isJnlpDeployment() {
-
-		// Para comprobar si estamos en un despliegue JNLP sin crear una dependencia
-		// con javaws, hacemos una llamada equivalente a:
-		//     javax.jnlp.ServiceManager.lookup("javax.jnlp.ExtendedService");
-		// Si falla la llamda, no estamos en un despliegue JNLP
-		try {
-			final Class<?> serviceManagerClass = Class.forName("javax.jnlp.ServiceManager"); //$NON-NLS-1$
-			final Method lookupMethod = serviceManagerClass.getMethod("lookup", String.class); //$NON-NLS-1$
-			lookupMethod.invoke(null, "javax.jnlp.ExtendedService"); //$NON-NLS-1$
-		}
-		catch (final Throwable e) {
-			return false;
-		}
-		return true;
 	}
 	
 	  /** Recupera el sistema operativo de ejecuci&oacute;n.

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/CommandLineLauncher.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/CommandLineLauncher.java
@@ -360,7 +360,7 @@ final class CommandLineLauncher {
  		if (inputFile == null) {
  			throw new CommandLineException(CommandLineMessages.getString("CommandLineLauncher.5"), true);  //$NON-NLS-1$
  		}
- 		new VisorFirma(true, null).initialize(false, inputFile);
+ 		new VisorFirma(true, null).initialize(inputFile);
  	}
 
 	/** Mostramos el panel de firmas. Se usara la configuraci&oacute;n de firma establecida

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/DesktopUtil.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/DesktopUtil.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -160,10 +159,6 @@ public final class DesktopUtil {
 	 */
 	public static File getApplicationDirectory() {
 
-		if (isJnlpDeployment()) {
-			return getJNLPApplicationDirectory();
-		}
-
 		// Identificamos el directorio de instalacion
 		try {
 			return new File(
@@ -199,27 +194,6 @@ public final class DesktopUtil {
 			filename = "Autofirma"; //$NON-NLS-1$
 		}
 		return filename;
-	}
-
-	/**
-	 * Obtiene el directorio de aplicaci&oacute;n que corresponde cuando se
-	 * ejecuta la aplicaci&oacute;n mediante un despliegue es JNLP.
-	 * @return Directorio de aplicaci&oacute;n.
-	 */
-	public static File getJNLPApplicationDirectory() {
-		if (Platform.getOS() == Platform.OS.WINDOWS) {
-			final File appDir = getWindowsAlternativeAppDir();
-			if (appDir.isDirectory() || appDir.mkdirs()) {
-				return appDir;
-			}
-		}
-		else if (Platform.getOS() == Platform.OS.MACOSX) {
-			final File appDir = getMacOsXAlternativeAppDir();
-			if (appDir.isDirectory() || appDir.mkdirs()) {
-				return appDir;
-			}
-		}
-		return new File(System.getProperty("java.io.tmpdir")); //$NON-NLS-1$
 	}
 
 	/**
@@ -268,28 +242,6 @@ public final class DesktopUtil {
 			appDir = getMacOsXAlternativeAppDir();
 		}
 		return appDir;
-	}
-
-	/**
-	 * Comprueba si estamos en un despliegue JNLP de la aplicaci&oacute;n.
-	 * @return {@code true} si estamos en un despliegue JNLP, {@code false}
-	 * en caso contrario.
-	 */
-	private static boolean isJnlpDeployment() {
-
-		// Para comprobar si estamos en un despliegue JNLP sin crear una dependencia
-		// con javaws, hacemos una llamada equivalente a:
-		//     javax.jnlp.ServiceManager.lookup("javax.jnlp.ExtendedService");
-		// Si falla la llamda, no estamos en un despliegue JNLP
-		try {
-			final Class<?> serviceManagerClass = Class.forName("javax.jnlp.ServiceManager"); //$NON-NLS-1$
-			final Method lookupMethod = serviceManagerClass.getMethod("lookup", String.class); //$NON-NLS-1$
-			lookupMethod.invoke(null, "javax.jnlp.ExtendedService"); //$NON-NLS-1$
-		}
-		catch (final Throwable e) {
-			return false;
-		}
-		return true;
 	}
 
 	/** Recupera el DPI de la pantalla principal.

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/VisorFirma.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/VisorFirma.java
@@ -21,7 +21,6 @@ import java.awt.event.WindowListener;
 import java.io.File;
 import java.util.Locale;
 
-import javax.swing.JApplet;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -34,10 +33,7 @@ import es.gob.afirma.standalone.ui.VisorPanel;
 
 /** Ventana para la visualizaci&oacute;n de datos de firma.
  * @author Carlos Gamuci. */
-public class VisorFirma extends JApplet implements WindowListener {
-
-    /** Serial ID */
-    private static final long serialVersionUID = 7060676034863587322L;
+public class VisorFirma implements WindowListener {
 
 	/** Anchura por defecto con la que se muestra inicialmente la pantalla principal. */
 	private static final int DEFAULT_WINDOW_WIDTH = 780;
@@ -67,9 +63,8 @@ public class VisorFirma extends JApplet implements WindowListener {
     }
 
     /** Reinicia la pantalla con los datos de una nueva firma.
-     * @param asApplet Indica que si se desea cargar la pantalla en forma de Applet.
      * @param sigFile Nuevo fichero de firma. */
-    public void initialize(final boolean asApplet, final File sigFile) {
+    public void initialize(final File sigFile) {
 
         if (sigFile != null) {
             this.signFile = sigFile;
@@ -82,64 +77,69 @@ public class VisorFirma extends JApplet implements WindowListener {
 		}
         setDefaultLocale(buildLocale(defaultLocale));
 
+        this.currentPanel = new VisorPanel(
+    		this.signFile,
+    		null,
+    		this,
+    		this.standalone
+		);
 
-        if (asApplet) {
-            this.container = this;
+        if (this.parentComponent == null) {
+           	final MainScreen mainScreen = new MainScreen();
+           	mainScreen.showMainScreen(this, this.currentPanel, DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
+            this.container = mainScreen;
         }
         else {
-            this.currentPanel = new VisorPanel(
-        		this.signFile,
-        		null,
-        		this,
-        		this.standalone
-    		);
+        	JDialog dialog;
+        	if (this.parentComponent instanceof Frame) {
+        		dialog = new JDialog((Frame) this.parentComponent);
+        	}
+        	else if (this.parentComponent instanceof Window) {
+        		dialog = new JDialog((Window) this.parentComponent);
+        	}
+        	else if (this.parentComponent instanceof Dialog) {
+        		dialog = new JDialog((Dialog) this.parentComponent);
+        	}
+        	else {
+        		dialog = new JDialog();
+        	}
+        	dialog.setModalityType(ModalityType.APPLICATION_MODAL);
+        	dialog.setSize(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
 
-            if (this.parentComponent == null) {
-	           	final MainScreen mainScreen = new MainScreen();
-	           	mainScreen.showMainScreen(this, this.currentPanel, DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
-	            this.container = mainScreen;
-            }
-            else {
-            	JDialog dialog;
-            	if (this.parentComponent instanceof Frame) {
-            		dialog = new JDialog((Frame) this.parentComponent);
-            	}
-            	else if (this.parentComponent instanceof Window) {
-            		dialog = new JDialog((Window) this.parentComponent);
-            	}
-            	else if (this.parentComponent instanceof Dialog) {
-            		dialog = new JDialog((Dialog) this.parentComponent);
-            	}
-            	else {
-            		dialog = new JDialog();
-            	}
-            	dialog.setModalityType(ModalityType.APPLICATION_MODAL);
-            	dialog.setSize(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
-
-            	final Point cp = GraphicsEnvironment.getLocalGraphicsEnvironment().getCenterPoint();
-        		dialog.setLocation(cp.x - DEFAULT_WINDOW_WIDTH/2, cp.y - DEFAULT_WINDOW_WIDTH/2);
-        		dialog.add(this.currentPanel);
-            	this.container = dialog;
-            }
-
-            if (this.window != null) {
-                this.window.dispose();
-            }
-
-            this.window = (Window) this.container;
-            if (this.window instanceof JFrame) {
-            	((JFrame)this.window).getRootPane().putClientProperty("Window.documentFile", this.signFile); //$NON-NLS-1$
-            	((JFrame)this.window).setTitle(SimpleAfirmaMessages.getString("VisorFirma.0") + (this.signFile != null ? " - " + this.signFile.getAbsolutePath() : ""));  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            	if (LookAndFeelManager.needMaximizeWindow()) {
-            		((JFrame)this.window).setExtendedState(((JFrame)this.window).getExtendedState() | Frame.MAXIMIZED_BOTH);
-            	}
-            }
-            else if (this.window instanceof JDialog) {
-            	((JDialog)this.window).getRootPane().putClientProperty("Window.documentFile", this.signFile); //$NON-NLS-1$
-            	((JDialog)this.window).setTitle(SimpleAfirmaMessages.getString("VisorFirma.0") + (this.signFile != null ? " - " + this.signFile.getAbsolutePath() : ""));  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            	this.window.setVisible(true);
-            }
+        	final Point cp = GraphicsEnvironment.getLocalGraphicsEnvironment().getCenterPoint();
+    		dialog.setLocation(cp.x - DEFAULT_WINDOW_WIDTH/2, cp.y - DEFAULT_WINDOW_WIDTH/2);
+    		dialog.add(this.currentPanel);
+        	this.container = dialog;
         }
+
+        if (this.window != null) {
+            this.window.dispose();
+        }
+
+        this.window = (Window) this.container;
+        if (this.window instanceof JFrame) {
+        	((JFrame)this.window).getRootPane().putClientProperty("Window.documentFile", this.signFile); //$NON-NLS-1$
+        	((JFrame)this.window).setTitle(SimpleAfirmaMessages.getString("VisorFirma.0") + (this.signFile != null ? " - " + this.signFile.getAbsolutePath() : ""));  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        	if (LookAndFeelManager.needMaximizeWindow()) {
+        		((JFrame)this.window).setExtendedState(((JFrame)this.window).getExtendedState() | Frame.MAXIMIZED_BOTH);
+        	}
+        }
+        else if (this.window instanceof JDialog) {
+        	((JDialog)this.window).getRootPane().putClientProperty("Window.documentFile", this.signFile); //$NON-NLS-1$
+        	((JDialog)this.window).setTitle(SimpleAfirmaMessages.getString("VisorFirma.0") + (this.signFile != null ? " - " + this.signFile.getAbsolutePath() : ""));  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        	this.window.setVisible(true);
+        }
+    }
+
+    /** Reinicia la pantalla con los datos de una nueva firma.
+     * @param asApplet Par&aacute;metro ignorado. El visor ya no puede cargarse como
+     *                 <i>applet</i>, ya que la API de <i>applets</i> se elimin&oacute;
+     *                 de la plataforma Java.
+     * @param sigFile Nuevo fichero de firma.
+     * @deprecated Util&iacute;cese {@link #initialize(File)}. */
+    @Deprecated
+    public void initialize(final boolean asApplet, final File sigFile) {
+    	initialize(sigFile);
     }
 
     /**
@@ -220,8 +220,10 @@ public class VisorFirma extends JApplet implements WindowListener {
         if (sgFile == null) {
             return;
         }
-        initialize(VisorFirma.this.equals(VisorFirma.this.container), sgFile);
+        initialize(sgFile);
 
-        repaint();
+        if (this.container != null) {
+        	this.container.repaint();
+        }
     }
 }

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/MainMenu.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/MainMenu.java
@@ -536,7 +536,7 @@ public final class MainMenu extends JMenuBar {
     		return;
     	}
     	if (file != null && file.length > 0 && file[0] != null && file[0].isFile()) {
-    		new VisorFirma(false, null).initialize(false, file[0]);
+    		new VisorFirma(false, null).initialize(file[0]);
     	} else {
     		AOUIFactory.showErrorMessage(
 			        SimpleAfirmaMessages.getString("SignPanel.123"), //$NON-NLS-1$

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/MassiveResultProcessPanel.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/MassiveResultProcessPanel.java
@@ -357,7 +357,7 @@ final class MassiveResultProcessPanel extends JPanel {
 		if (index >= 0) {
 			final SignOperationConfig item = list.getModel().getElementAt(index);
 			if (item.getSignatureFile() != null) {
-				SwingUtilities.invokeLater(() -> new VisorFirma(false, parent).initialize(false, item.getSignatureFile()));
+				SwingUtilities.invokeLater(() -> new VisorFirma(false, parent).initialize(item.getSignatureFile()));
 			}
 		}
 	}

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/SignPanelFilePanel.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/SignPanelFilePanel.java
@@ -83,7 +83,7 @@ final class SignPanelFilePanel extends JPanel implements Scrollable {
         	openFileButton.addActionListener(
         			ae -> {
         				if (file.getName().endsWith(".csig") || file.getName().endsWith(".xsig")) { //$NON-NLS-1$ //$NON-NLS-2$
-        					new VisorFirma(false, null).initialize(false, file);
+        					new VisorFirma(false, null).initialize(file);
         				}
         				else {
         					try {

--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/SignPanelMultiFilePanel.java
+++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/ui/SignPanelMultiFilePanel.java
@@ -152,7 +152,7 @@ final class SignPanelMultiFilePanel extends JPanel implements Scrollable {
     		// y se abriran con el visor, mientras que el resto a traves de la aplicacion asociada
     		// en el sistema
     		if (signConfig.getSignValidity() != null) {
-    			new VisorFirma(false, null).initialize(false, signConfig.getDataFile());
+    			new VisorFirma(false, null).initialize(signConfig.getDataFile());
     		}
     		else {
     			SwingUtilities.invokeLater(() -> {

--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/AutofirmaConfigurator.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/AutofirmaConfigurator.java
@@ -53,8 +53,6 @@ public class AutofirmaConfigurator implements ConsoleListener {
 	 * del proceso de instalaci&oacute;n. */
 	public static final String PARAMETER_HEADLESS = "-headless"; //$NON-NLS-1$
 
-	/** Indica que se realiza una carga mediante JNLP. */
-	public static final String PARAMETER_JNLP_INSTANCE = "-jnlp"; //$NON-NLS-1$
 
 	/** Indica que debe habilitarse el que Firefox utilice los certificados de confianza del sistema. */
 	public static final String PARAMETER_FIREFOX_SECURITY_ROOTS = "-firefox_roots"; //$NON-NLS-1$
@@ -154,20 +152,14 @@ public class AutofirmaConfigurator implements ConsoleListener {
 
 		this.config = config;
 
-		final boolean jnlpDeployment = this.config.isJnlpInstance();
-		if (jnlpDeployment) {
-			LOGGER.info("Se configurara la aplicacion en modo JNLP"); //$NON-NLS-1$
-		}
-		else {
-			LOGGER.info("Se configurara la aplicacion en modo nativo"); //$NON-NLS-1$
-		}
+		LOGGER.info("Se configurara la aplicacion en modo nativo"); //$NON-NLS-1$
 
 		if (Platform.OS.WINDOWS.equals(Platform.getOS())) {
-			this.configurator = new ConfiguratorWindows(jnlpDeployment, this.config.isFirefoxSecurityRoots(),
+			this.configurator = new ConfiguratorWindows(this.config.isFirefoxSecurityRoots(),
 					this.config.getCertificatePath(), this.config.getKeystorePath());
 		}
 		else if (Platform.OS.LINUX == Platform.getOS()){
-		    this.configurator = new ConfiguratorLinux(jnlpDeployment);
+		    this.configurator = new ConfiguratorLinux();
 		}
 		else if (Platform.OS.MACOSX == Platform.getOS()){
             this.configurator = new ConfiguratorMacOSX(this.config.isHeadless(), this.config.isFirefoxSecurityRoots());
@@ -417,7 +409,6 @@ public class AutofirmaConfigurator implements ConsoleListener {
 		private Operation op = Operation.INSTALLATION;
 		private boolean needKeep = false;
 		private boolean headless = false;
-		private boolean jnlpInstance = false;
 		private boolean firefoxSecurityRoots = false;
 		private String certificatePath = ""; //$NON-NLS-1$
 		private String keystorePath = ""; //$NON-NLS-1$
@@ -439,8 +430,6 @@ public class AutofirmaConfigurator implements ConsoleListener {
 						this.needKeep = true;
 					} else if (PARAMETER_HEADLESS.equalsIgnoreCase(arg)) {
 						this.headless = true;
-					} else if (PARAMETER_JNLP_INSTANCE.equalsIgnoreCase(arg)) {
-						this.jnlpInstance = true;
 					} else if (PARAMETER_FIREFOX_SECURITY_ROOTS.equalsIgnoreCase(arg)) {
 						this.firefoxSecurityRoots = true;
 					} else if (PARAMETER_CERTIFICATE_PATH.equalsIgnoreCase(arg)) {
@@ -474,10 +463,6 @@ public class AutofirmaConfigurator implements ConsoleListener {
 
 		public boolean isHeadless() {
 			return this.headless;
-		}
-
-		public boolean isJnlpInstance() {
-			return this.jnlpInstance;
 		}
 
 		public boolean isFirefoxSecurityRoots() {

--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/AutofirmaConfiguratorSilent.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/AutofirmaConfiguratorSilent.java
@@ -140,11 +140,11 @@ public final class AutofirmaConfiguratorSilent implements ConsoleListener {
 		this.config = config;
 
 		if (Platform.OS.WINDOWS.equals(Platform.getOS())) {
-			this.configurator = new ConfiguratorWindows(false, this.config.isFirefoxSecurityRoots(),
+			this.configurator = new ConfiguratorWindows(this.config.isFirefoxSecurityRoots(),
 					this.config.getCertificatePath(), this.config.getKeystorePath());
 		}
 		else if (Platform.OS.LINUX == Platform.getOS()){
-		    this.configurator = new ConfiguratorLinux(false);
+		    this.configurator = new ConfiguratorLinux();
 		}
 		else if (Platform.OS.MACOSX == Platform.getOS()){
             this.configurator = new ConfiguratorMacOSX(true, this.config.isFirefoxSecurityRoots());

--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorLinux.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorLinux.java
@@ -40,7 +40,6 @@ final class ConfiguratorLinux implements Configurator {
 
 	static final Logger LOGGER = Logger.getLogger("es.gob.afirma"); //$NON-NLS-1$
 
-	private static final String ALTERNATIVE_APP_SUBDIR = ".afirma/Autofirma"; //$NON-NLS-1$
 
 	private static final String UNINSTALL_SCRIPT_NAME = "uninstall.sh"; //$NON-NLS-1$
 	private static final String INSTALL_SCRIPT_NAME = "script.sh"; //$NON-NLS-1$
@@ -49,18 +48,12 @@ final class ConfiguratorLinux implements Configurator {
     private static final String FILE_AUTOFIRMA_CERTIFICATE = "Autofirma_ROOT.cer"; //$NON-NLS-1$
     private static final String KS_PASSWORD = "654321"; //$NON-NLS-1$
 
-	private final boolean jnlpInstance;
-
-    public ConfiguratorLinux(final boolean jnlpInstance) {
-		this.jnlpInstance = jnlpInstance;
-	}
-
     @Override
     public void configure(final Console window) throws IOException, GeneralSecurityException, HeadlessException {
 
         LOGGER.info(Messages.getString("ConfiguratorLinux.2")); //$NON-NLS-1$
 
-        final File appDir = getApplicationDirectory(this.jnlpInstance);
+        final File appDir = getApplicationDirectory();
 
         LOGGER.info(Messages.getString("ConfiguratorLinux.3") + appDir.getAbsolutePath()); //$NON-NLS-1$
 
@@ -128,45 +121,14 @@ final class ConfiguratorLinux implements Configurator {
         return new File(appConfigDir, KS_FILENAME).exists();
     }
 
-	private static File getApplicationDirectory(final boolean jnlpDeployment) {
-
-		// Devolver un directorio que utilizar como directorio de instalacion cuando
-		// se realice un despliegue JNLP
-		if (jnlpDeployment) {
-			try {
-				return getIntApplicationDirectory();
-			} catch (final IOException e) {
-				LOGGER.severe("No se encuentra ni ha podido generarse el directorio de aplicacion: " + e); //$NON-NLS-1$
-			}
-		}
+	private static File getApplicationDirectory() {
 
 		return ConfiguratorUtil.getApplicationDirectory();
 	}
 
-	/** Obtiene un directorio en el que almacenar los ficheros de la aplicaci&oacute;n.
-	 * @return Directorio de aplicaci&oacute;n.
-	 * @throws IOException EN cualquier error. */
-	private static File getIntApplicationDirectory() throws IOException {
-		final String userHome;
-		try {
-			userHome = System.getProperty("user.home"); //$NON-NLS-1$
-		}
-		catch (final Exception e) {
-			throw new IOException("No se ha podido identificar el directorio del usuario para almacenar los ficheros de instalacion", e); //$NON-NLS-1$
-		}
-		if (userHome == null) {
-			throw new IOException("No se encuentra definido el directorio del usuario"); //$NON-NLS-1$
-		}
-		final File appDir = new File(userHome, ALTERNATIVE_APP_SUBDIR);
-		if (!appDir.isDirectory() && !appDir.mkdirs()) {
-			throw new IOException("No ha podido crearse el directorio para los ficheros de aplicacion"); //$NON-NLS-1$
-		}
-		return appDir;
-	}
-
 	@Override
 	public File getAplicationDirectory() {
-		return getApplicationDirectory(false);
+		return getApplicationDirectory();
 	}
 
 	@Override

--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorWindows.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/ConfiguratorWindows.java
@@ -22,8 +22,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
@@ -31,7 +29,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.swing.JOptionPane;
 
 import es.gob.afirma.core.misc.LoggerUtil;
 import es.gob.afirma.standalone.configurator.CertUtil.CertPack;
@@ -58,13 +55,11 @@ final class ConfiguratorWindows implements Configurator {
 	 */
 	private static final int UNINSTALL_CERT_RETRIES = 3;
 
-	private final boolean jnlpInstance;
 	private final boolean firefoxSecurityRoots;
 	private final String certificatePath;
 	private final String keyStorePath;
 
-	public ConfiguratorWindows(final boolean jnlpInstance, final boolean firefoxSecurityRoots, final String certificatePath, final String keyStorePath) {
-		this.jnlpInstance = jnlpInstance;
+	public ConfiguratorWindows(final boolean firefoxSecurityRoots, final String certificatePath, final String keyStorePath) {
 		this.firefoxSecurityRoots = firefoxSecurityRoots;
 		this.certificatePath = certificatePath;
 		this.keyStorePath = keyStorePath;
@@ -75,7 +70,7 @@ final class ConfiguratorWindows implements Configurator {
 
 		window.print(Messages.getString("ConfiguratorWindows.2")); //$NON-NLS-1$
 
-		final File appDir = getApplicationDirectory(this.jnlpInstance);
+		final File appDir = getApplicationDirectory();
 
 		window.print(Messages.getString("ConfiguratorWindows.3") + appDir.getAbsolutePath()); //$NON-NLS-1$
 
@@ -129,14 +124,6 @@ final class ConfiguratorWindows implements Configurator {
 						certPack.getCaCertificate().getEncoded(),
 						new File(appDir, CA_CERT_FILENAME));
 
-				// En los despliegues JNLP nunca se proporcionan certificados. Ademas, en estos casos, el
-				// instalador no lo habra instalado en el almacen de Windows, asi que lo tendremos que
-				// hacer ahora
-				if (this.jnlpInstance) {
-					JOptionPane.showMessageDialog(window.getParentComponent(), Messages.getString("ConfiguratorWindows.17")); //$NON-NLS-1$
-					window.print(Messages.getString("ConfiguratorWindows.6")); //$NON-NLS-1$
-					importCARootOnWindowsKeyStore(certPack.getCaCertificate(), CertUtil.ROOT_CERTIFICATE_PRINCIPAL);
-				}
 			}
 
 			// Intentamos desinstalar cualquier certificado nuestro que pueda haber antes de instalar el nuevo
@@ -178,31 +165,17 @@ final class ConfiguratorWindows implements Configurator {
 		window.print(Messages.getString("ConfiguratorWindows.8")); //$NON-NLS-1$
 	}
 
-	/** Recupera el directorio de la aplicaci&oacute;n, que podr&aacute; variar
-	 * seg&uacute;n si est&aacute; instalada o si se trata de un despliegue JNLP.
-	 * @param jnlpDeployment <code>true</code> si se trata de un despliegue JNLP,
-	 *                       <code>false</code> en caso contrario.
+	/** Recupera el directorio de la aplicaci&oacute;n.
 	 * @return Directorio en el que se almacenan los recursos de la aplicaci&oacute;n.
 	 */
-	private static File getApplicationDirectory(final boolean jnlpDeployment) {
-
-		// Si el despliegue es JNLP seleccionamos un directorio de Windows en el que
-		// se puedan crear los ficheros sin permisos especiales
-		if (jnlpDeployment) {
-			final String commonDir = System.getenv("ALLUSERSPROFILE"); //$NON-NLS-1$
-			final File appDir = new File (commonDir, "Autofirma"); //$NON-NLS-1$
-			if (appDir.isDirectory() || appDir.mkdirs()) {
-				return appDir;
-			}
-			return new File(System.getProperty("java.io.tmpdir")); //$NON-NLS-1$
-		}
+	private static File getApplicationDirectory() {
 
 		return ConfiguratorUtil.getApplicationDirectory();
 	}
 
 	@Override
 	public File getAplicationDirectory() {
-		return getApplicationDirectory(false);
+		return getApplicationDirectory();
 	}
 
 	@Override
@@ -226,7 +199,7 @@ final class ConfiguratorWindows implements Configurator {
 
 		LOGGER.info("Desinstalamos el certificado raiz del almacen de Firefox"); //$NON-NLS-1$
 		ConfiguratorFirefoxWindows.uninstallRootCAMozillaKeyStore(
-				getApplicationDirectory(this.jnlpInstance),
+				getApplicationDirectory(),
 				console,
 				UNINSTALL_CERT_RETRIES);
 
@@ -292,54 +265,13 @@ final class ConfiguratorWindows implements Configurator {
 		LOGGER.info("Eliminamos la entrada de Autofirma en el PATH"); //$NON-NLS-1$
 		try {
 			final Path cmd = WindowsCmdExecutor.copyCmdFromResources("windows/autofirma-removepath.cmd"); //$NON-NLS-1$
-			WindowsCmdExecutor.executePathCmd(cmd, WAITING_TIME_IN_SECONDS, getApplicationDirectory(false).getAbsolutePath());
+			WindowsCmdExecutor.executePathCmd(cmd, WAITING_TIME_IN_SECONDS, getApplicationDirectory().getAbsolutePath());
 		} catch (final Exception e) {
 			LOGGER.log(Level.WARNING, "No se pudo eliminar correctamente la ruta de instalacion de la variable PATH", e); //$NON-NLS-1$
 		}
 
 		// No es necesario eliminar nada mas porque el proceso de desinstalacion de Windows
 		// eliminara el directorio de aplicacion con todo su contenido
-	}
-
-	/**
-	 * Instala el certificado SSL en el almac&eacute;n de autoridades de confianza Windows
-	 * sin necesidad de tener permisos de administrador.
-	 * @param cert Certificado a instalar.
-	 * @param principal Principal del certificado.
-	 * @throws GeneralSecurityException Cuando no se tiene acceso al almac&eacute;n de
-	 * autoridades de certificaci&oacute;n.
-	 * @throws IOException Cuando no se pudo cargar el almac&eacute;n.
-	 */
-	private static void importCARootOnWindowsKeyStore(final Certificate cert, final String principal) throws GeneralSecurityException, IOException {
-
-		final KeyStore ks = KeyStore.getInstance("Windows-ROOT"); //$NON-NLS-1$
-		ks.load(null,  null);
-
-		boolean installed = false;
-		boolean cancelled = false;
-		do {
-			try {
-				ks.setCertificateEntry(principal, cert);
-				installed = true;
-			}
-			catch (final KeyStoreException e) {
-				LOGGER.warning(
-						"No se pudo instalar la CA del certificado SSL para el socket en el almacen de Windows: " + e //$NON-NLS-1$
-						);
-				final int result = JOptionPane.showConfirmDialog(
-						null,
-						Messages.getString("ConfiguratorWindows.0"), //$NON-NLS-1$
-						Messages.getString("ConfiguratorWindows.1"), //$NON-NLS-1$
-						JOptionPane.OK_CANCEL_OPTION,
-						JOptionPane.WARNING_MESSAGE
-						);
-				if (result == JOptionPane.CANCEL_OPTION) {
-					cancelled = true;
-					LOGGER.severe("El usuario cancelo la instalacion del certificado SSL para el socket: " + e); //$NON-NLS-1$
-				}
-			}
-		}
-		while (!installed && !cancelled);
 	}
 
 	/**
@@ -361,7 +293,7 @@ final class ConfiguratorWindows implements Configurator {
 		}
 
 		String certAlias;
-		final File caCertFile = new File(getApplicationDirectory(false), CA_CERT_FILENAME);
+		final File caCertFile = new File(getApplicationDirectory(), CA_CERT_FILENAME);
 		if (caCertFile.isFile() && caCertFile.canRead()) {
 			try (InputStream certInputStream = new FileInputStream(caCertFile)) {
 				final CertificateFactory certFactory = CertificateFactory.getInstance("X.509"); //$NON-NLS-1$

--- a/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/DirectoryUtil.java
+++ b/afirma-ui-simple-configurator/src/main/java/es/gob/afirma/standalone/configurator/DirectoryUtil.java
@@ -1,7 +1,6 @@
 package es.gob.afirma.standalone.configurator;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
@@ -76,10 +75,6 @@ public class DirectoryUtil {
 	
 	private static File getApplicationDirectory() {
 
-		if (isJnlpDeployment()) {
-			return getJNLPApplicationDirectory();
-		}
-
 		// Identificamos el directorio de instalacion
 		try {
 			return new File(
@@ -93,47 +88,4 @@ public class DirectoryUtil {
 		return null;
 	}
 	
-	/**
-	 * Obtiene el directorio de aplicaci&oacute;n que corresponde cuando se
-	 * ejecuta la aplicaci&oacute;n mediante un despliegue es JNLP.
-	 * @return Directorio de aplicaci&oacute;n.
-	 */
-	private static File getJNLPApplicationDirectory() {
-		if (Platform.getOS() == Platform.OS.WINDOWS) {
-			final File appDir = getWindowsAlternativeAppDir();
-			if (appDir.isDirectory() || appDir.mkdirs()) {
-				return appDir;
-			}
-		}
-		else if (Platform.getOS() == Platform.OS.MACOSX) {
-			final File appDir = getMacOsXAlternativeAppDir();
-			if (appDir.isDirectory() || appDir.mkdirs()) {
-				return appDir;
-			}
-		}
-		return new File(System.getProperty("java.io.tmpdir")); //$NON-NLS-1$
-	}
-	
-	/**
-	 * Comprueba si estamos en un despliegue JNLP de la aplicaci&oacute;n.
-	 * @return {@code true} si estamos en un despliegue JNLP, {@code false}
-	 * en caso contrario.
-	 */
-	private static boolean isJnlpDeployment() {
-
-		// Para comprobar si estamos en un despliegue JNLP sin crear una dependencia
-		// con javaws, hacemos una llamada equivalente a:
-		//     javax.jnlp.ServiceManager.lookup("javax.jnlp.ExtendedService");
-		// Si falla la llamda, no estamos en un despliegue JNLP
-		try {
-			final Class<?> serviceManagerClass = Class.forName("javax.jnlp.ServiceManager"); //$NON-NLS-1$
-			final Method lookupMethod = serviceManagerClass.getMethod("lookup", String.class); //$NON-NLS-1$
-			lookupMethod.invoke(null, "javax.jnlp.ExtendedService"); //$NON-NLS-1$
-		}
-		catch (final Throwable e) {
-			return false;
-		}
-		return true;
-	}
-
 }


### PR DESCRIPTION
## Resultado

Se elimina el último uso de la API de *applets* (`JApplet`) en los módulos que
se construyen y todo el soporte de Java Web Start

Closes https://github.com/ctt-gob-es/clienteafirma/issues/518

## Cambios

**Visor de firmas**

`VisorFirma` deja de extender `javax.swing.JApplet` y queda como
`WindowListener`, que es la función que ya cumplía: controlador de la ventana
del visor y de los botones de `VisorPanel`. Se elimina la rama de carga como
*applet*, `initialize(boolean, File)` pasa a ser `initialize(File)` y se
actualizan sus cinco llamantes.

La rama eliminada era inalcanzable: todos los llamantes pasaban
`asApplet = false`, la única llamada dinámica evaluaba
`this.equals(this.container)` —cierto solo si esa rama se hubiera ejecutado
antes— y la instancia nunca se añade a ningún contenedor. El cuerpo resultante
es idéntico al de la rama `else` anterior; el diff crece solo por la
reindentación.

**Java Web Start**

Se retira la sonda reflexiva de `javax.jnlp.ServiceManager`, duplicada en
`DesktopUtil`, `DirectoryUtil` y `LanguageUtils`; el parámetro `-jnlp` del
configurador junto con su directorio de aplicación alternativo y la rama que
importaba la CA en el almacén de Windows; y la lectura de `jnlpx.home` en
`Platform.recoverJavaHome()`.

Ningún instalador, fichero `.desktop`, entrada NSIS o `.spec` pasa `-jnlp`, los
argumentos desconocidos se ignoran y `AutofirmaConfiguratorSilent` ya pasaba
`false`, de modo que la instalación silenciosa no cambia de comportamiento.

## Verificación

`mvn -P env-dev,autofirma compile` correcto. En los módulos que se construyen
no queda ninguna referencia a `JApplet`, `java.applet` ni `jnlp`; las que
permanecen están en los módulos obsoletos del Applet, el MiniApplet y WebStart,
que no se construyen y cuya retirada se propondrá por separado.

##Trabajo futuro

Se propone: 

- Trasladar los módulos no mantenidos ni construidos a una nueva rama [modulos-no-mantenidos]
- Eliminar los módulos no mantenidos ni construidos del cliente de autofirma, de la rama main / develop.

